### PR TITLE
Complex Filter Expressions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ set(STA_SOURCE
   sdc/DeratingFactors.cc
   sdc/DisabledPorts.cc
   sdc/ExceptionPath.cc
+  sdc/FilterExpr.cc
   sdc/InputDrive.cc
   sdc/PinPair.cc
   sdc/PortDelay.cc

--- a/include/sta/FilterExpr.hh
+++ b/include/sta/FilterExpr.hh
@@ -23,16 +23,58 @@
 // This notice may not be removed or altered from any source distribution.
 
 #pragma once
-
-#include "StringUtil.hh"
-#include "Vector.hh"
+#include <string>
+#include "StringSeq.hh"
 
 namespace sta {
 
-typedef Vector<const char*> StringSeq;
-typedef std::vector<string> StdStringSeq;
+using std::string;
 
-void
-deleteContents(StringSeq *strings);
+class FilterSyntaxError : public Exception
+{
+public:
+  explicit FilterSyntaxError(const char* error);
+  virtual ~FilterSyntaxError() noexcept {}
+  virtual const char *what() const noexcept;
+
+private:
+  std::string error_;
+};
+
+class FilterUnexpectedCharacter : public Exception
+{
+public:
+  explicit FilterUnexpectedCharacter(const char* error);
+  virtual ~FilterUnexpectedCharacter() noexcept {}
+  virtual const char *what() const noexcept;
+
+private:
+  std::string error_;
+};
+
+class FilterExpr {
+public:
+    struct Token {
+        enum class Kind {
+            skip = 0,
+            predicate,
+            op_and,
+            op_or,
+            op_lparen,
+            op_rparen,
+        };
+        std::string text;
+        Kind kind;
+    };
+    
+    FilterExpr(std::string expression);
+    
+    std::vector<std::string> postfix(bool sta_boolean_props_as_int);
+private:
+    std::vector<Token> lex(bool sta_boolean_props_as_int);
+    std::vector<Token> shuntingYard(const std::vector<Token>& infix);
+    
+    std::string raw_;
+};
 
 } // namespace

--- a/sdc/FilterExpr.cc
+++ b/sdc/FilterExpr.cc
@@ -1,0 +1,159 @@
+// OpenSTA, Static Timing Analyzer
+// Copyright (c) 2025, Parallax Software, Inc.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+// 
+// The origin of this software must not be misrepresented; you must not
+// claim that you wrote the original software.
+// 
+// Altered source versions must be plainly marked as such, and must not be
+// misrepresented as being the original software.
+// 
+// This notice may not be removed or altered from any source distribution.
+
+#include "Error.hh"
+#include "FilterExpr.hh"
+
+#include <regex>
+#include <stack>
+#include <functional>
+
+using namespace sta;
+
+FilterSyntaxError::FilterSyntaxError(const char *what)  :
+  Exception()
+{
+  error_ = what;
+}
+
+const char *
+FilterUnexpectedCharacter::what() const noexcept
+{
+  return error_.c_str();
+}
+
+FilterUnexpectedCharacter::FilterUnexpectedCharacter(const char *starting_at)  :
+  Exception()
+{
+  error_ = "unexpected character starting at: '";
+  error_ += starting_at;
+  error_ += "'";
+}
+
+const char *
+FilterUnexpectedCharacter::what() const noexcept
+{
+  return error_.c_str();
+}
+
+FilterExpr::FilterExpr(std::string expression): raw_(expression) {}
+
+std::vector<std::string> FilterExpr::postfix(bool sta_boolean_props_as_int) {
+    auto infix = lex(sta_boolean_props_as_int);
+    auto postfix = shuntingYard(infix);
+    std::vector<std::string> result;
+    for (auto& token: postfix) {
+        result.push_back(token.text);
+    }
+    return result;
+}
+
+std::vector<FilterExpr::Token> FilterExpr::lex(bool sta_boolean_props_as_int) {
+    std::vector<std::pair<std::regex, FilterExpr::Token::Kind>> token_regexes = {
+        {std::regex("^\\s+"), FilterExpr::Token::Kind::skip},
+        {std::regex("^@?([a-zA-Z_]+) *((==|!=|=~|!~) *([0-9a-zA-Z_\\/$\\[\\]*]+))?"), FilterExpr::Token::Kind::predicate},
+        {std::regex("^(&&)"), FilterExpr::Token::Kind::op_and},
+        {std::regex("^(\\|\\|)"), FilterExpr::Token::Kind::op_or},
+        {std::regex("^(\\()"), FilterExpr::Token::Kind::op_lparen},
+        {std::regex("^(\\))"), FilterExpr::Token::Kind::op_rparen},
+    };
+    
+    std::vector<FilterExpr::Token> result;
+    const char* ptr = &raw_[0];
+    bool match = false;
+    while (*ptr != 0) {
+        match = false;
+        for (auto& [regex, kind]: token_regexes) {
+            std::cmatch token_match;
+            if (std::regex_search(ptr, token_match, regex)) {
+                if (kind == FilterExpr::Token::Kind::predicate) {
+                    std::string final_predicate;
+                    if (token_match[2].length() == 0 && token_match[3].length() == 0) { // empty final match
+                        final_predicate = token_match[1].str() + " == " + (sta_boolean_props_as_int ? "1" : "true");
+                    } else {
+                        final_predicate = token_match[1].str() + " " + token_match[3].str() + " " + token_match[4].str();
+                    }
+                    auto token = Token { final_predicate, kind };
+                    result.push_back(token);
+                } else if (kind != FilterExpr::Token::Kind::skip) {
+                    auto token = Token { std::string(ptr, token_match.length()), kind };
+                    result.push_back(token);
+                }
+                ptr += token_match.length();
+                match = true;
+                break;
+            };
+        }
+        if (!match) {
+            throw FilterUnexpectedCharacter(ptr);
+        }
+    }
+    return result;
+}
+
+std::vector<FilterExpr::Token> FilterExpr::shuntingYard(const std::vector<Token>& infix) {
+    std::vector<FilterExpr::Token> output;
+    std::stack<FilterExpr::Token> operator_stack;
+    
+    for (auto& token: infix) {
+        switch (token.kind) {
+        case FilterExpr::Token::Kind::predicate:
+            output.push_back(token);
+            break;
+        case FilterExpr::Token::Kind::op_or:
+            while (operator_stack.size() && operator_stack.top().kind == FilterExpr::Token::Kind::op_and) {
+                output.push_back(operator_stack.top());
+                operator_stack.pop();
+            }
+        case FilterExpr::Token::Kind::op_and:
+        case FilterExpr::Token::Kind::op_lparen:
+            operator_stack.push(token);
+            break;
+        case FilterExpr::Token::Kind::op_rparen:
+            if (operator_stack.empty()) {
+                throw FilterSyntaxError("extraneous ) in expression");
+            }
+            while (operator_stack.size() && operator_stack.top().kind != FilterExpr::Token::Kind::op_lparen) {
+                output.push_back(operator_stack.top());
+                operator_stack.pop();   
+                if (operator_stack.empty()) {
+                    throw FilterSyntaxError("extraneous ) in expression");
+                }
+            }
+            // guaranteed to be lparen at this point
+            operator_stack.pop();
+            break;
+        }
+    }
+    
+    while (operator_stack.size()) {
+        if (operator_stack.top().kind == FilterExpr::Token::Kind::op_lparen) {
+            throw FilterSyntaxError("unmatched ( in expression");
+        }
+        output.push_back(operator_stack.top());
+        operator_stack.pop();
+    }
+    
+    return output;
+}

--- a/sdc/Sdc.i
+++ b/sdc/Sdc.i
@@ -31,6 +31,7 @@
 #include "PortDelay.hh"
 #include "Property.hh"
 #include "Sta.hh"
+#include "FilterExpr.hh"
 
 using namespace sta;
 
@@ -1384,6 +1385,12 @@ pin_logic_value(const Pin *pin)
   bool exists;
   sdc->logicValue(pin, value, exists);
   return logicValueString(value);
+}
+
+////////////////////////////////////////////////////////////////
+
+StdStringSeq filter_expr_to_postfix(const char* infix, bool sta_boolean_props_as_int) {
+  return sta::FilterExpr(infix).postfix(sta_boolean_props_as_int);
 }
 
 ////////////////////////////////////////////////////////////////

--- a/sdc/Sdc.tcl
+++ b/sdc/Sdc.tcl
@@ -306,26 +306,51 @@ proc current_design { {design ""} } {
 
 # Generic get_* filter.
 proc filter_objs { filter objects filter_function object_type } {
-  set filter_regexp1 {@?([a-zA-Z_]+) *((==|!=|=~|!~) *([0-9a-zA-Z_\\/$\[\]*]+))?}
-  set filter_or_regexp "($filter_regexp1) *\\|\\| *($filter_regexp1)"
-  set filter_and_regexp "($filter_regexp1) *&& *($filter_regexp1)"
-  set filtered_objects {}
-  # Ignore sub-exprs in filter_regexp1 for expr2 match var.
-  if { [regexp $filter_or_regexp $filter ignore expr1 ignore ignore ignore ignore expr2] } {
-    set filtered_objects1 [filter_objs $expr1 $objects $filter_function $object_type]
-    set filtered_objects2 [filter_objs $expr2 $objects $filter_function $object_type]
-    set filtered_objects [concat $filtered_objects1 $filtered_objects2]
-  } elseif { [regexp $filter_and_regexp $filter ignore expr1 ignore ignore ignore ignore expr2] } {
-    set filtered_objects [filter_objs $expr1 $objects $filter_function $object_type]
-    set filtered_objects [filter_objs $expr2 $filtered_objects $filter_function $object_type]
-  } elseif { [regexp $filter_regexp1 $filter ignore attr_name ignore op arg] } {
-    set op [expr {($op == "") ? "==" : $op}]
-    set arg [expr {($arg == "") ? ($::sta_boolean_props_as_int ? "1" : "true") : $arg}]
-    set filtered_objects [$filter_function $attr_name $op $arg $objects]
-  } else {
-    sta_error 350 "unsupported $object_type -filter expression."
+  if {[catch {set postfix [filter_expr_to_postfix $filter $::sta_boolean_props_as_int]} error]} {
+    sta_error 350 "unsupported $object_type -filter expression: $error."
   }
-  return $filtered_objects
+  set eval_stack [list]
+  foreach token $postfix {
+    if { $token == "||" || $token == "&&" } {
+      set arg0 [lindex $eval_stack end]
+      set arg1 [lindex $eval_stack end-1]
+      set eval_stack [lreplace $eval_stack end-1 end]
+      if { "$token" == "||" } {
+        set union_result [lsort -unique "$arg0 $arg1"]
+        lappend eval_stack $union_result
+      } else {
+        set intersect_result [list]
+        
+        # Tcl does not have a dedicated set type built-in. What it does have
+        # is sneaky optimizations for the dict type. The following squeezes
+        # just a tiny bit of extra performance compared to the full-on O(n^2)
+        # approach.
+        set lookup [dict create]
+        foreach obj $arg0 {
+          dict set lookup $obj exist
+        }
+        foreach obj $arg1 {
+          if { [dict exists $lookup $obj]} {
+            lappend intersect_result $obj
+          }
+        }
+        lappend eval_stack $intersect_result
+      }
+    } else {
+      # Token dissected into attr op arg format during filter expression infix
+      # to postfix conversion.
+      lassign $token attr_name op arg
+      set filter_result [$filter_function $attr_name $op $arg $objects]
+      lappend eval_stack $filter_result
+    }
+  }
+  if { [llength $eval_stack] >= 2 } {
+    sta_error 624 "filter expression evaluated to multiple objects"
+  }
+  if { [llength $eval_stack] == 0 } {
+    sta_error 625 "filter expression is empty"
+  }
+  return [lindex $eval_stack 0]
 }
 
 ################################################################

--- a/tcl/StaTclTypes.i
+++ b/tcl/StaTclTypes.i
@@ -322,6 +322,16 @@ using namespace sta;
   Tcl_SetObjResult(interp, list);
 }
 
+%typemap(out) StdStringSeq {
+  StdStringSeq &strs = $1;
+  Tcl_Obj *list = Tcl_NewListObj(0, nullptr);
+  for (string& str : strs) {
+    Tcl_Obj *obj = Tcl_NewStringObj(str.c_str(), str.length());
+    Tcl_ListObjAppendElement(interp, list, obj);
+  }
+  Tcl_SetObjResult(interp, list);
+}
+
 %typemap(out) Library* {
   Tcl_Obj *obj = SWIG_NewInstanceObj($1, $1_descriptor, false);
   Tcl_SetObjResult(interp, obj);


### PR DESCRIPTION
Implements support for parentheses in filter expressions using a new C++ expression parser implementing the shunting yard algorithm, which returns a postfix expression that is then evaluated in Tcl.

filter_objs was reworked to use set unions and intersections as the previous approach would not support complex expressions.