### PR TITLE
hotfix: linux build issue

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,5 +1,5 @@
 name: Build and run tests
-on: [push]
+on: [push, pull_request]
 
 jobs:
   linux-docker:

--- a/include/sta/FilterExpr.hh
+++ b/include/sta/FilterExpr.hh
@@ -23,7 +23,9 @@
 // This notice may not be removed or altered from any source distribution.
 
 #pragma once
+
 #include <string>
+#include <memory>
 #include "StringSeq.hh"
 #include "Error.hh"
 


### PR DESCRIPTION
Fixes FilterExpr.hh failing to compile with libstdc++.

Also activates the CI on pull requests to prevent this from happening again.