### PR TITLE
liberty: add visitor for defines, save raw define types

### DIFF
--- a/liberty/LibertyParser.cc
+++ b/liberty/LibertyParser.cc
@@ -81,9 +81,10 @@ LibertyParser::makeDefine(LibertyAttrValueSeq *values,
     LibertyAttrType value_type = attrValueType(value_type_name);
     LibertyGroupType group_type = groupType(group_type_name);
     define = new LibertyDefine(define_name, group_type,
-			       value_type, line);
+			       value_type, line, group_type_name, value_type_name);
     LibertyGroup *group = this->group();
     group->addDefine(define);
+    group_visitor_->visitDefine(define);
   }
   else
     report_->fileWarn(24, filename_.c_str(), line,
@@ -464,11 +465,15 @@ LibertyFloatAttrValue::stringValue()
 LibertyDefine::LibertyDefine(const char *name,
 			     LibertyGroupType group_type,
 			     LibertyAttrType value_type,
-			     int line) :
+			     int line,
+			     const char *group_type_raw,
+			     const char *value_type_raw) :
   LibertyStmt(line),
   name_(name),
   group_type_(group_type),
-  value_type_(value_type)
+  value_type_(value_type),
+  group_type_raw_(group_type_raw),
+  value_type_raw_(value_type_raw)
 {
 }
 

--- a/liberty/LibertyParser.hh
+++ b/liberty/LibertyParser.hh
@@ -263,18 +263,24 @@ class LibertyDefine : public LibertyStmt
 {
 public:
   LibertyDefine(const char *name,
-		LibertyGroupType group_type,
-		LibertyAttrType value_type,
-		int line);
+    LibertyGroupType group_type,
+    LibertyAttrType value_type,
+    int line,
+    const char *group_type_raw,
+    const char *value_type_raw);
   virtual bool isDefine() const { return true; }
   const char *name() const { return name_.c_str(); }
   LibertyGroupType groupType() const { return group_type_; }
   LibertyAttrType valueType() const { return value_type_; }
+  std::string_view groupTypeRaw() const { return group_type_raw_; }
+  std::string_view valueTypeRaw() const { return value_type_raw_; }
 
 private:
   std::string name_;
   LibertyGroupType group_type_;
   LibertyAttrType value_type_;
+  std::string group_type_raw_;
+  std::string value_type_raw_;
 };
 
 // The Liberty User Guide Version 2003.12 fails to document variables.
@@ -305,6 +311,7 @@ public:
   virtual void end(LibertyGroup *group) = 0;
   virtual void visitAttr(LibertyAttr *attr) = 0;
   virtual void visitVariable(LibertyVariable *variable) = 0;
+  virtual void visitDefine(LibertyDefine *define) {}
   // Predicates to save parse structure after visits.
   virtual bool save(LibertyGroup *group) = 0;
   virtual bool save(LibertyAttr *attr) = 0;


### PR DESCRIPTION
* liberty/LibertyParser.hh::LibertyGroupVisitor: Add overridable function for visiting defines, with the default implementation (to avoid breaking backwards compatibility) doing nothing
* liberty/LibertyParser.hh::LibertyDefine: Record "raw" names for both the group type and the value type: data loss occurs otherwise for custom group names and custom value types
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance `LibertyParser` to visit defines and store raw define types, updating `LibertyDefine` and `LibertyGroupVisitor`.
> 
>   - **LibertyParser Enhancements**:
>     - `makeDefine()` in `LibertyParser.cc` now calls `visitDefine()` on `group_visitor_` after adding a define.
>     - `LibertyDefine` constructor updated to store raw group and value type names.
>   - **LibertyDefine Class**:
>     - Added `groupTypeRaw()` and `valueTypeRaw()` to return raw type names.
>   - **LibertyGroupVisitor Interface**:
>     - Added `visitDefine()` as an overridable function with a default no-op implementation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Silimate%2FOpenSTA&utm_source=github&utm_medium=referral)<sup> for a139ee85385858b34185e5b335f925344abfce7d. You can [customize](https://app.ellipsis.dev/Silimate/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->