### PR TITLE
Add ability to get both Input and Output internal power components from InternalPower calculation

### DIFF
--- a/include/sta/PowerClass.hh
+++ b/include/sta/PowerClass.hh
@@ -78,16 +78,22 @@ public:
   PowerResult();
   void clear();
   float internal() const { return internal_; }
+  float inputinternal() const { return inputinternal_; }
+  float outputinternal() const { return outputinternal_; }
   float switching() const { return switching_; }
   float leakage() const { return leakage_; }
   float total() const;
   void incr(PowerResult &result);
   void incrInternal(float pwr);
+  void incrInputInternal(float pwr);
+  void incrOutputInternal(float pwr);
   void incrSwitching(float pwr);
   void incrLeakage(float pwr);
 
 private:
   float internal_;
+  float inputinternal_;
+  float outputinternal_;
   float switching_;
   float leakage_;
 };

--- a/power/Power.cc
+++ b/power/Power.cc
@@ -954,6 +954,7 @@ Power::findInputInternalPower(const Pin *pin,
         internal += port_internal;
       }
       result.incrInternal(internal);
+      result.incrInputInternal(internal);
     }
   }
 }
@@ -1045,7 +1046,9 @@ Power::findOutputInternalPower(const LibertyPort *to_port,
   FuncExpr *func = to_port->function();
 
   map<const char*, float, StringLessIf> pg_duty_sum;
+  int N_arcs = 0; // SILIMATE
   for (InternalPower *pwr : corner_cell->internalPowers(to_corner_port)) {
+    N_arcs += 1;
     const LibertyPort *from_corner_port = pwr->relatedPort();
     if (from_corner_port) {
       const Pin *from_pin = findLinkPin(inst, from_corner_port);
@@ -1060,6 +1063,7 @@ Power::findOutputInternalPower(const LibertyPort *to_port,
   debugPrint(debug_, "power", 2,
              "             when act/ns  duty  wgt   energy    power");
   float internal = 0.0;
+  float out_internal = 0.0; // SILIMATE
   for (InternalPower *pwr : corner_cell->internalPowers(to_corner_port)) {
     FuncExpr *when = pwr->when();
     const char *related_pg_pin = pwr->relatedPgPin();
@@ -1100,6 +1104,7 @@ Power::findOutputInternalPower(const LibertyPort *to_port,
       }
     }
     float port_internal = weight * energy * to_activity.density();
+    float avg_arc_internal = energy * to_activity.density();
     debugPrint(debug_, "power", 2,  "%3s -> %-3s %6s  %.3f %.3f %.3f %9.2e %9.2e %s",
                from_corner_port ? from_corner_port->name() : "-" ,
                to_port->name(),
@@ -1111,8 +1116,13 @@ Power::findOutputInternalPower(const LibertyPort *to_port,
                port_internal,
                related_pg_pin ? related_pg_pin : "no pg_pin");
     internal += port_internal;
+    out_internal += avg_arc_internal;
   }
   result.incrInternal(internal);
+  if (N_arcs)
+    result.incrOutputInternal(out_internal / (N_arcs/2));
+  else
+    result.incrOutputInternal(0.0);
 }
 
 float
@@ -1524,6 +1534,8 @@ Power::clockMinPeriod()
 
 PowerResult::PowerResult() :
   internal_(0.0),
+  inputinternal_(0.0),
+  outputinternal_(0.0),
   switching_(0.0),
   leakage_(0.0)
 {
@@ -1533,6 +1545,8 @@ void
 PowerResult::clear() 
 {
   internal_ = 0.0;
+  inputinternal_ = 0.0;
+  outputinternal_ = 0.0;
   switching_ = 0.0;
   leakage_ = 0.0;
 }
@@ -1547,6 +1561,18 @@ void
 PowerResult::incrInternal(float pwr)
 {
   internal_ += pwr;
+}
+// SILIMATE
+void
+PowerResult::incrInputInternal(float pwr)
+{
+  inputinternal_ += pwr;
+}
+
+void
+PowerResult::incrOutputInternal(float pwr)
+{
+  outputinternal_ += pwr;
 }
 
 void
@@ -1565,6 +1591,8 @@ void
 PowerResult::incr(PowerResult &result)
 {
   internal_ += result.internal_;
+  inputinternal_ += result.inputinternal_;
+  outputinternal_ += result.outputinternal_;
   switching_ += result.switching_;
   leakage_ += result.leakage_;
 }

--- a/power/Power.i
+++ b/power/Power.i
@@ -46,6 +46,14 @@ pushPowerResultFloats(PowerResult &power,
   powers.push_back(power.leakage());
   powers.push_back(power.total());
 }
+static void
+pushInternalPowerComponents(PowerResult &power,
+                          FloatSeq &powers)
+{
+  // SILIMATE
+  powers.push_back(power.inputinternal());
+  powers.push_back(power.outputinternal());
+}
 
 FloatSeq
 design_power(const Corner *corner)
@@ -59,6 +67,17 @@ design_power(const Corner *corner)
   pushPowerResultFloats(clock, powers);
   pushPowerResultFloats(macro, powers);
   pushPowerResultFloats(pad, powers);
+  return powers;
+}
+
+FloatSeq
+internal_power_components(const Corner *corner)
+{
+  // SILIMATE
+  PowerResult total, sequential, combinational, clock, macro, pad;
+  Sta::sta()->power(corner, total, sequential, combinational, clock, macro, pad);
+  FloatSeq powers;
+  pushInternalPowerComponents(total, powers);
   return powers;
 }
 

--- a/power/Power.i
+++ b/power/Power.i
@@ -50,7 +50,6 @@ static void
 pushInternalPowerComponents(PowerResult &power,
                           FloatSeq &powers)
 {
-  // SILIMATE
   powers.push_back(power.inputinternal());
   powers.push_back(power.outputinternal());
 }
@@ -73,7 +72,6 @@ design_power(const Corner *corner)
 FloatSeq
 internal_power_components(const Corner *corner)
 {
-  // SILIMATE
   PowerResult total, sequential, combinational, clock, macro, pad;
   Sta::sta()->power(corner, total, sequential, combinational, clock, macro, pad);
   FloatSeq powers;

--- a/power/Power.tcl
+++ b/power/Power.tcl
@@ -68,14 +68,15 @@ proc_redirect report_power {
     report_power_design $corner $digits
   }
 }
-# Silimate
-define_cmd_args "report_internal_power_components" \
-  {
-      [> filename] [>> filename] }
+
+define_cmd_args "report_internal_power_components" { [> filename] [>> filename] }
 proc_redirect report_internal_power_components {
   global sta_report_default_digits
   # Set the default corner
   set corner [cmd_corner]
+  if { ![liberty_libraries_exist] } {
+    sta_error 304 "No liberty libraries have been read."
+  }
   set power_result [internal_power_components $corner]
   report_line $power_result
 }

--- a/power/Power.tcl
+++ b/power/Power.tcl
@@ -68,6 +68,18 @@ proc_redirect report_power {
     report_power_design $corner $digits
   }
 }
+# Silimate
+define_cmd_args "report_internal_power_components" \
+  {
+      [> filename] [>> filename] }
+proc_redirect report_internal_power_components {
+  global sta_report_default_digits
+  # Set the default corner
+  set corner [cmd_corner]
+  set power_result [internal_power_components $corner]
+  report_line $power_result
+}
+
 
 proc liberty_libraries_exist {} {
   set lib_iter [liberty_library_iterator]


### PR DESCRIPTION
* Decomposes InternalPower into Input (which is the internal power consumed on the inputs of the cell), and Output (which is the internal power consumed on the outputs of the cell)
* Introduces `sta::report_internal_power_components` command, which reports `input_internal_power output_internal_power` on the same line

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Decomposes internal power into input and output components and adds a command to report these components in OpenSTA.
> 
>   - **Behavior**:
>     - Decomposes internal power into `input_internal_power` and `output_internal_power` in `PowerResult`.
>     - Adds `sta::report_internal_power_components` command in `Power.tcl` to report these components.
>   - **Functions**:
>     - Adds `incrInputInternal()` and `incrOutputInternal()` to `PowerResult` in `PowerClass.hh` and `Power.cc`.
>     - Modifies `findInputInternalPower()` and `findOutputInternalPower()` in `Power.cc` to calculate and store input and output internal power.
>   - **Misc**:
>     - Adds `pushInternalPowerComponents()` in `Power.i` to support new reporting command.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Silimate%2FOpenSTA&utm_source=github&utm_medium=referral)<sup> for 0cc0be40bb6926c473ca76a95a6917d784bb3f70. You can [customize](https://app.ellipsis.dev/Silimate/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->