### PR TITLE
Make sure output internal power is instantiated to 0.0

### DIFF
--- a/power/Power.cc
+++ b/power/Power.cc
@@ -1123,6 +1123,8 @@ Power::findOutputInternalPower(const LibertyPort *to_port,
   result.incrInternal(internal);
   if (numInternalPowerPins)
     result.incrOutputInternal(out_internal / numInternalPowerPins);
+  else
+    result.incrOutputInternal(0.0);
 }
 
 float


### PR DESCRIPTION
Without incrementing the output internal power by 0.0 in the findOutputInternalPower function, it seems like in some cases the OutputInternalPower value was getting set to NaN
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes potential `NaN` issue in `findOutputInternalPower()` in `Power.cc` by ensuring `OutputInternalPower` is incremented by `0.0` when `numInternalPowerPins` is zero.
> 
>   - **Behavior**:
>     - Fixes potential `NaN` issue in `findOutputInternalPower()` in `Power.cc` by ensuring `OutputInternalPower` is incremented by `0.0` when `numInternalPowerPins` is zero.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Silimate%2FOpenSTA&utm_source=github&utm_medium=referral)<sup> for 4047245e70b1a1dbb37fe45bc2b233aa3bfca35d. You can [customize](https://app.ellipsis.dev/Silimate/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->