### PR TITLE
JSON power reports

### DIFF
--- a/tcl/Util.tcl
+++ b/tcl/Util.tcl
@@ -185,6 +185,17 @@ proc define_hidden_cmd_args { cmd arglist } {
   namespace export $cmd
 }
 
+# "Optional Upvar"
+# If $other_var is not empty, the upvar is executed.
+# Otherwise, $my_var is set to empty.
+proc upvar_opt { level other_var my_var } {
+  if { $other_var != "" } {
+    uplevel 1 "upvar $level $other_var $my_var"
+  } else {
+    uplevel 1 "set $my_var \"\""
+  }
+}
+
 ################################################################
 
 proc sta_warn { msg_id msg } {

--- a/test/power_json.ok
+++ b/test/power_json.ok
@@ -1,0 +1,91 @@
+Warning: ../examples/gcd_sky130hd.v line 527, module sky130_fd_sc_hd__tapvpwrvgnd_1 not found. Creating black box for TAP_11.
+{
+  "Sequential": {
+    "internal": 0.0003066031204070896 ,
+    "switching": 4.756392809213139e-5 ,
+    "leakage": 2.9606700424622545e-10 , 
+    "total": 0.00035416733589954674 , 
+    "percent": 40.00543943400957 
+  }
+  ,
+  "Combinational": {
+    "internal": 0.00015870876086410135 ,
+    "switching": 0.0002051054034382105 ,
+    "leakage": 6.858974499479586e-10 , 
+    "total": 0.00036381487734615803 , 
+    "percent": 41.09519022666588 
+  }
+  ,
+  "Clock": {
+    "internal": 4.6827732148813084e-5 ,
+    "switching": 0.00012048805365338922 ,
+    "leakage": 2.300374994657073e-11 , 
+    "total": 0.00016731581126805395 , 
+    "percent": 18.899378557978626 
+  }
+  ,
+  "Macro": {
+    "internal": 0.0 ,
+    "switching": 0.0 ,
+    "leakage": 0.0 , 
+    "total": 0.0 , 
+    "percent": 0.0 
+  }
+  ,
+  "Pad": {
+    "internal": 0.0 ,
+    "switching": 0.0 ,
+    "leakage": 0.0 , 
+    "total": 0.0 , 
+    "percent": 0.0 
+  }
+  ,
+  "Total": {
+    "internal": 0.0005121395224705338 ,
+    "switching": 0.00037315741064958274 ,
+    "leakage": 1.0049683307755686e-9 , 
+    "total": 0.0008852979517541826 , 
+    "percent": 100.0 
+  }
+}
+[
+{
+  "name": "clkbuf_2_3__f_clk",
+  "internal": 9.388037142343819e-6 ,
+  "switching": 2.5721039492054842e-5 ,
+  "leakage": 4.600749902577972e-12 ,
+  "total": 3.510908209136687e-5
+}
+,
+{
+  "name": "clkbuf_2_0__f_clk",
+  "internal": 9.381412382936105e-6 ,
+  "switching": 2.5163068130495958e-5 ,
+  "leakage": 4.600749902577972e-12 ,
+  "total": 3.454448233242147e-5
+}
+,
+{
+  "name": "clkbuf_2_1__f_clk",
+  "internal": 9.367196980747394e-6 ,
+  "switching": 2.3965205400600098e-5 ,
+  "leakage": 4.600749902577972e-12 ,
+  "total": 3.33324060193263e-5
+}
+,
+{
+  "name": "clkbuf_2_2__f_clk",
+  "internal": 9.359226169181056e-6 ,
+  "switching": 2.3292685000342317e-5 ,
+  "leakage": 4.600749902577972e-12 ,
+  "total": 3.265191480750218e-5
+}
+,
+{
+  "name": "clkbuf_0_clk",
+  "internal": 9.331858564110007e-6 ,
+  "switching": 2.2346057448885404e-5 ,
+  "leakage": 4.600749902577972e-12 ,
+  "total": 3.1677918741479516e-5
+}
+]

--- a/test/power_json.tcl
+++ b/test/power_json.tcl
@@ -1,0 +1,13 @@
+# report_power gcd
+read_liberty ../examples/sky130hd_tt.lib.gz
+read_verilog ../examples/gcd_sky130hd.v
+link_design gcd
+
+read_sdc ../examples/gcd_sky130hd.sdc
+set_propagated_clock clk
+read_spef ../examples/gcd_sky130hd.spef
+set_power_activity -input -activity .1
+set_power_activity -input_port reset -activity 0
+
+report_power -format json
+report_power -format json -instances "[get_cells -filter "name=~clkbuf*"]"

--- a/test/regression_vars.tcl
+++ b/test/regression_vars.tcl
@@ -161,6 +161,7 @@ record_sta_tests {
   path_dedup_worst
   pin_props
   prima3
+  power_json
   report_checks_src_attr
   report_json1
   report_json2


### PR DESCRIPTION
- power/Power.tcl:
  - add -format flag to report_power, two options: "text", "json"
  - modified report_power_design, report_power_insts to accept a report format and modified accordingly
  - modified report_power_inst, report_power_row to accept both a report format and sentinel variables (to add commas for valid json output)
- tcl/Util.tcl: added new convenience function upvar_opt
- added test for power_json
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds JSON output support for power reports and includes a test case to verify the functionality.
> 
>   - **Behavior**:
>     - Adds `-format` flag to `report_power` in `Power.tcl` with options "text" and "json".
>     - Updates `report_power_design`, `report_power_insts`, `report_power_inst`, and `report_power_row` to handle JSON format.
>   - **Utilities**:
>     - Adds `upvar_opt` function in `Util.tcl` for optional variable linking.
>   - **Testing**:
>     - Adds `power_json.tcl` test to verify JSON output for power reports.
>     - Registers `power_json` test in `regression_vars.tcl`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Silimate%2FOpenSTA&utm_source=github&utm_medium=referral)<sup> for e32a6f07b0bb0b368f17f9070b1050046709e280. You can [customize](https://app.ellipsis.dev/Silimate/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->