### PR TITLE
[ENG-1973] Bus timing

### DIFF
--- a/liberty/LibertyReader.cc
+++ b/liberty/LibertyReader.cc
@@ -2039,8 +2039,10 @@ LibertyReader::finishPortGroups()
     }
     makeTimingArcs(port_group);
     makeInternalPowers(port_group);
-    delete port_group;
   }
+  // Defer deletion until after the loop so overrides can safely walk.
+  for (PortGroup *port_group : cell_port_groups_)
+    delete port_group;
   cell_port_groups_.clear();
 }
 
@@ -2520,6 +2522,48 @@ TimingGroup::makeTableModels(LibertyCell *cell,
   }
 }
 
+bool
+LibertyReader::sameArcIdentity(TimingGroup *pin_t,
+                               TimingGroup *bus_timing,
+                               const char *from_port_name)
+{
+  // Check timing type, conditions, and related port names for overriding bus bit pins.
+  if (pin_t->attrs()->timingType() != bus_timing->attrs()->timingType())
+    return false;
+  if (!FuncExpr::equiv(pin_t->attrs()->cond(), bus_timing->attrs()->cond()))
+    return false;
+  if (pin_t->relatedPortNames() == nullptr)
+    return false;
+  for (const char *n : *pin_t->relatedPortNames()) {
+    if (stringEq(n, from_port_name))
+      return true;
+  }
+  return false;
+}
+
+bool
+LibertyReader::hasBitPinTimingOverride(LibertyPort *to_port_bit,
+                                       const char *from_port_name,
+                                       TimingGroup *bus_timing)
+{
+  // Check if the to port bit is in any of the bus port groups.
+  for (PortGroup *pg : cell_port_groups_) {
+    bool group_lists_bit = false;
+    for (LibertyPort *p : *pg->ports()) {
+      if (p == to_port_bit)
+        group_lists_bit = true;
+    }
+    if (group_lists_bit) {
+      // Check if the bus timing group is the same as the pin timing group.
+      for (TimingGroup *pin_t : pg->timingGroups()) {
+        if (sameArcIdentity(pin_t, bus_timing, from_port_name))
+          return true;
+      }
+    }
+  }
+  return false;
+}
+
 void
 LibertyReader::makeTimingArcs(const char *from_port_name,
 			      PortNameBitIterator &from_port_iter,
@@ -2555,9 +2599,12 @@ LibertyReader::makeTimingArcs(const char *from_port_name,
         libWarn(1214, timing->line(), "timing group from output port.");
       LibertyPortMemberIterator bit_iter(to_port);
       while (bit_iter.hasNext()) {
-	LibertyPort *to_port_bit = bit_iter.next();
-	builder_.makeTimingArcs(cell_, from_port, to_port_bit, related_out_port,
-                                timing->attrs(), timing->line());
+        LibertyPort *to_port_bit = bit_iter.next();
+        // Do not override if the bus bit has a timing arc defined at the pin level.
+        if (!hasBitPinTimingOverride(to_port_bit, from_port_name, timing))
+          builder_.makeTimingArcs(cell_, from_port, to_port_bit,
+                                  related_out_port,
+                                  timing->attrs(), timing->line());
       }
     }
   }

--- a/liberty/LibertyReader.cc
+++ b/liberty/LibertyReader.cc
@@ -2596,7 +2596,6 @@ LibertyReader::makeTimingArcs(const char *from_port_name,
 			      LibertyPort *related_out_port,
 			      TimingGroup *timing)
 {
-  printf("from_port_name: %s\n", from_port_name);
   if (from_port_iter.size() == 1 && !to_port->hasMembers()) {
     // one -> one
     if (from_port_iter.hasNext()) {

--- a/liberty/LibertyReader.cc
+++ b/liberty/LibertyReader.cc
@@ -2527,13 +2527,15 @@ LibertyReader::sameArcIdentity(TimingGroup *pin_t,
                                TimingGroup *bus_timing,
                                const char *from_port_name)
 {
-  // Check timing type, conditions, and related port names for overriding bus bit pins.
+  // Check timing types are equivalent.
   if (pin_t->attrs()->timingType() != bus_timing->attrs()->timingType())
     return false;
+  // Check conditions are equivalent.
   if (!FuncExpr::equiv(pin_t->attrs()->cond(), bus_timing->attrs()->cond()))
     return false;
   if (pin_t->relatedPortNames() == nullptr)
     return false;
+  // Check if the from port name is in the related port names.
   for (const char *n : *pin_t->relatedPortNames()) {
     if (stringEq(n, from_port_name))
       return true;

--- a/liberty/LibertyReader.cc
+++ b/liberty/LibertyReader.cc
@@ -2031,6 +2031,20 @@ LibertyReader::endCell(LibertyGroup *group)
 void
 LibertyReader::finishPortGroups()
 {
+  // Populate bit_overrides_ with the timing groups of each port.
+  bit_overrides_.clear();
+  for (PortGroup *port_group : cell_port_groups_) {
+    if (port_group->timingGroups().empty())
+      continue;
+    for (LibertyPort *port : *port_group->ports()) {
+      // Map port to timing groups in it.
+      std::vector<TimingGroup*> &timingGroups = bit_overrides_[port];
+      for (TimingGroup *timing : port_group->timingGroups())
+        timingGroups.push_back(timing);
+    }
+  }
+
+  // Make timing arcs for each port group.
   for (PortGroup *port_group : cell_port_groups_) {
     int line = port_group->line();
     for (LibertyPort *port : *port_group->ports()) {
@@ -2523,46 +2537,55 @@ TimingGroup::makeTableModels(LibertyCell *cell,
 }
 
 bool
+LibertyReader::relatedPinIncludesPort(TimingGroup *t,
+                                      LibertyPort *from_port,
+                                      int line)
+{
+  if (t->relatedPortNames() == nullptr) // no related pin
+    return false;
+  // Check every related port name for a matching port.
+  for (const char *related_pin : *t->relatedPortNames()) {
+    PortNameBitIterator it(cell_, related_pin, this, line);
+    while (it.hasNext()) {
+      if (it.next() == from_port)
+        return true;
+    }
+  }
+  return false;
+}
+
+bool
 LibertyReader::sameArcIdentity(TimingGroup *pin_t,
                                TimingGroup *bus_timing,
-                               const char *from_port_name)
+                               LibertyPort *from_port)
 {
-  // Check timing types are equivalent.
-  if (pin_t->attrs()->timingType() != bus_timing->attrs()->timingType())
-    return false;
-  // Check conditions are equivalent.
-  if (!FuncExpr::equiv(pin_t->attrs()->cond(), bus_timing->attrs()->cond()))
-    return false;
-  if (pin_t->relatedPortNames() == nullptr)
-    return false;
-  // Check if the from port name is in the related port names.
-  for (const char *n : *pin_t->relatedPortNames()) {
-    if (stringEq(n, from_port_name))
-      return true;
+  // Check that the timing types are the same.
+  if (pin_t->attrs()->timingType() == bus_timing->attrs()->timingType()) {
+    // Check that the conditions are equivalent.
+    if (FuncExpr::equiv(pin_t->attrs()->cond(), bus_timing->attrs()->cond())) {
+      // Check that the related pins are the same.
+      if (from_port == nullptr && pin_t->relatedPortNames() == nullptr) {
+        return true;
+      }
+      return relatedPinIncludesPort(pin_t, from_port, bus_timing->line());
+    }
   }
   return false;
 }
 
 bool
 LibertyReader::hasBitPinTimingOverride(LibertyPort *to_port_bit,
-                                       const char *from_port_name,
+                                       LibertyPort *from_port,
                                        TimingGroup *bus_timing)
 {
-  // Check if the to port bit is in any of the bus port groups.
-  for (PortGroup *pg : cell_port_groups_) {
-    bool group_lists_bit = false;
-    for (LibertyPort *p : *pg->ports()) {
-      if (p == to_port_bit)
-        group_lists_bit = true;
-    }
-    if (group_lists_bit) {
-      // Check if the bus timing group is the same as the pin timing group.
-      for (TimingGroup *pin_t : pg->timingGroups()) {
-        if (sameArcIdentity(pin_t, bus_timing, from_port_name))
-          return true;
-      }
-    }
-  }
+  // Look for destination port bit in overrides map.
+  auto it = bit_overrides_.find(to_port_bit);
+  if (it == bit_overrides_.end())
+    return false;
+  // Check every timing group for the port in the overrides map.
+  for (TimingGroup *pin_t : it->second)
+    if (sameArcIdentity(pin_t, bus_timing, from_port))
+      return true;
   return false;
 }
 
@@ -2573,6 +2596,7 @@ LibertyReader::makeTimingArcs(const char *from_port_name,
 			      LibertyPort *related_out_port,
 			      TimingGroup *timing)
 {
+  printf("from_port_name: %s\n", from_port_name);
   if (from_port_iter.size() == 1 && !to_port->hasMembers()) {
     // one -> one
     if (from_port_iter.hasNext()) {
@@ -2602,8 +2626,8 @@ LibertyReader::makeTimingArcs(const char *from_port_name,
       LibertyPortMemberIterator bit_iter(to_port);
       while (bit_iter.hasNext()) {
         LibertyPort *to_port_bit = bit_iter.next();
-        // Do not override if the bus bit has a timing arc defined at the pin level.
-        if (!hasBitPinTimingOverride(to_port_bit, from_port_name, timing))
+        // Skip bits whose pin(<bit>) block declares a matching timing arc
+        if (!hasBitPinTimingOverride(to_port_bit, from_port, timing))
           builder_.makeTimingArcs(cell_, from_port, to_port_bit,
                                   related_out_port,
                                   timing->attrs(), timing->line());
@@ -2637,9 +2661,11 @@ LibertyReader::makeTimingArcs(const char *from_port_name,
 	LibertyPort *to_port_bit = to_port_iter.next();
 	if (from_port_bit->direction()->isOutput())
 	  libWarn(1215, timing->line(), "timing group from output port.");
-	builder_.makeTimingArcs(cell_, from_port_bit, to_port_bit,
-				related_out_port, timing->attrs(),
-				timing->line());
+        // Skip bits whose pin(<bit>) block declares a matching timing arc.
+        if (!hasBitPinTimingOverride(to_port_bit, from_port_bit, timing))
+          builder_.makeTimingArcs(cell_, from_port_bit, to_port_bit,
+                                  related_out_port, timing->attrs(),
+                                  timing->line());
       }
     }
     else {
@@ -2650,9 +2676,11 @@ LibertyReader::makeTimingArcs(const char *from_port_name,
 	LibertyPortMemberIterator to_iter(to_port);
 	while (to_iter.hasNext()) {
 	  LibertyPort *to_port_bit = to_iter.next();
-	  builder_.makeTimingArcs(cell_, from_port_bit, to_port_bit,
-                                  related_out_port, timing->attrs(),
-                                  timing->line());
+          // Skip bits whose pin(<bit>) block declares a matching timing arc.
+          if (!hasBitPinTimingOverride(to_port_bit, from_port_bit, timing))
+            builder_.makeTimingArcs(cell_, from_port_bit, to_port_bit,
+                                    related_out_port, timing->attrs(),
+                                    timing->line());
 	}
       }
     }

--- a/liberty/LibertyReaderPvt.hh
+++ b/liberty/LibertyReaderPvt.hh
@@ -209,11 +209,15 @@ public:
 			      TimingGroup *timing);
   
   // Helper functions for makeTimingArcs()
+  std::unordered_map<LibertyPort*, std::vector<TimingGroup*>> bit_overrides_;
+  bool relatedPinIncludesPort(TimingGroup *t,
+                              LibertyPort *from_port,
+                              int line);
   bool sameArcIdentity(TimingGroup *pin_t,
                        TimingGroup *bus_timing,
-                       const char *from_port_name);
+                       LibertyPort *from_port);
   bool hasBitPinTimingOverride(LibertyPort *to_port_bit,
-                               const char *from_port_name,
+                               LibertyPort *from_port,
                                TimingGroup *bus_timing);
 
   virtual void visitClockGatingIntegratedCell(LibertyAttr *attr);

--- a/liberty/LibertyReaderPvt.hh
+++ b/liberty/LibertyReaderPvt.hh
@@ -207,6 +207,14 @@ public:
   virtual void makeTimingArcs(LibertyPort *to_port,
                               LibertyPort *related_out_port,
 			      TimingGroup *timing);
+  
+  // Helper functions for makeTimingArcs()
+  bool sameArcIdentity(TimingGroup *pin_t,
+                       TimingGroup *bus_timing,
+                       const char *from_port_name);
+  bool hasBitPinTimingOverride(LibertyPort *to_port_bit,
+                               const char *from_port_name,
+                               TimingGroup *bus_timing);
 
   virtual void visitClockGatingIntegratedCell(LibertyAttr *attr);
   virtual void visitArea(LibertyAttr *attr);


### PR DESCRIPTION
Issue, given a bus and nested pin with the same timing types (when, related_pin, etc.) we will always pick the worst value (larger value), but we should pick the one that is nested deeper in the liberty cell's hierarchy.

Changes:
- EDITS to finishPortGroups()
  - Populate bit_overrides_ data structure (maps ports to their timing groups) for future lookups (time saver)
  - Delete cell_port_groups after creating timing arcs to allow for override validation.
- ADDED hasBitTimingOverride
  - Answers "does this bit in the bus have a pin declaration inside that should override the timing arc?"
  - If it doesn't we will create the timing arc using the BUS-level definitions
  - If it does, we will not create the timing arc and use the one created at the pin level
- ADDED sameArcIdentity
  - Answers "now that we know there exists a pin declaration for this bus bit, does it match exactly to the bus timing group definitions?"
  - Essentially validates related_pin, timing_sense, etc.
- ADDED relatedPinIncludesPort
  - Checks if the related pin between the bus and pin comparison we make are the same related pin.
- EDITS to makeTimingArcs
  - We will not create a timing arc for bus bits that have such an override since we should use the nested declaration
  - Only applies to pin->bus and bus->bus paths since the destination bit is what is used for the timing arc (won't use a nested pin declaration for a bus->pin since the pin timing arcs are used)