### PR TITLE
[ENG-1975] Fix clock rise/fall edge on 0 for non_seq timing types

### DIFF
--- a/sdc/CycleAccting.cc
+++ b/sdc/CycleAccting.cc
@@ -305,6 +305,7 @@ CycleAccting::setSetupAccting(int src_cycle,
   setAccting(TimingRole::outputSetup(), src_cycle, tgt_cycle, delay, req);
   setAccting(TimingRole::gatedClockSetup(), src_cycle, tgt_cycle, delay, req);
   setAccting(TimingRole::recovery(), src_cycle, tgt_cycle, delay, req);
+  setAccting(TimingRole::nonSeqSetup(), src_cycle, tgt_cycle, delay, req);
 }
 
 void
@@ -317,6 +318,7 @@ CycleAccting::setHoldAccting(int src_cycle,
   setAccting(TimingRole::outputHold(), src_cycle, tgt_cycle, delay, req);
   setAccting(TimingRole::removal(), src_cycle, tgt_cycle, delay, req);
   setAccting(TimingRole::latchHold(), src_cycle, tgt_cycle, delay, req);
+  setAccting(TimingRole::nonSeqHold(), src_cycle, tgt_cycle, delay, req);
 }
 
 void
@@ -358,6 +360,7 @@ CycleAccting::setDefaultSetupAccting(int src_cycle,
   setSetupAccting(src_cycle, tgt_cycle, delay, req);
   setAccting(TimingRole::latchSetup(), src_cycle, tgt_cycle, delay, req);
   setAccting(TimingRole::dataCheckSetup(), src_cycle, tgt_cycle, delay, req);
+  setAccting(TimingRole::nonSeqSetup(), src_cycle, tgt_cycle, delay, req);
 }
 
 void
@@ -368,6 +371,7 @@ CycleAccting::setDefaultHoldAccting(int src_cycle,
 {
   setHoldAccting(src_cycle, tgt_cycle, delay, req);
   setAccting(TimingRole::dataCheckHold(), src_cycle, tgt_cycle, delay, req);
+  setAccting(TimingRole::nonSeqHold(), src_cycle, tgt_cycle, delay, req);
 }
 
 float

--- a/sdc/CycleAccting.cc
+++ b/sdc/CycleAccting.cc
@@ -360,7 +360,6 @@ CycleAccting::setDefaultSetupAccting(int src_cycle,
   setSetupAccting(src_cycle, tgt_cycle, delay, req);
   setAccting(TimingRole::latchSetup(), src_cycle, tgt_cycle, delay, req);
   setAccting(TimingRole::dataCheckSetup(), src_cycle, tgt_cycle, delay, req);
-  setAccting(TimingRole::nonSeqSetup(), src_cycle, tgt_cycle, delay, req);
 }
 
 void
@@ -371,7 +370,6 @@ CycleAccting::setDefaultHoldAccting(int src_cycle,
 {
   setHoldAccting(src_cycle, tgt_cycle, delay, req);
   setAccting(TimingRole::dataCheckHold(), src_cycle, tgt_cycle, delay, req);
-  setAccting(TimingRole::nonSeqHold(), src_cycle, tgt_cycle, delay, req);
 }
 
 float

--- a/test/non_seq_timing.lib
+++ b/test/non_seq_timing.lib
@@ -1,0 +1,73 @@
+library(non_seq_timing) {
+    delay_model : table_lookup;
+    time_unit : "1ns";
+    capacitive_load_unit (1, pf);
+    input_threshold_pct_rise  : 50;
+    input_threshold_pct_fall  : 50;
+    output_threshold_pct_rise : 50;
+    output_threshold_pct_fall : 50;
+    slew_lower_threshold_pct_rise : 20;
+    slew_lower_threshold_pct_fall : 20;
+    slew_upper_threshold_pct_rise : 80;
+    slew_upper_threshold_pct_fall : 80;
+
+
+    cell(CKMUX) {
+        pin(CLK1)   { direction : input; }
+        pin(CLK2)   { direction : input; }
+        pin(CLKSEL) {
+            direction : input;
+            timing() {
+                related_pin : "CLK1";
+                timing_type : non_seq_setup_rising;
+                rise_constraint(scalar) { values ("0.050"); }
+                fall_constraint(scalar) { values ("0.050"); }
+            }
+            timing() {
+                related_pin : "CLK1";
+                timing_type : non_seq_hold_rising;
+                rise_constraint(scalar) { values ("0.020"); }
+                fall_constraint(scalar) { values ("0.020"); }
+            }
+            timing() {
+                related_pin : "CLK2";
+                timing_type : non_seq_setup_rising;
+                rise_constraint(scalar) { values ("0.050"); }
+                fall_constraint(scalar) { values ("0.050"); }
+            }
+            timing() {
+                related_pin : "CLK2";
+                timing_type : non_seq_hold_rising;
+                rise_constraint(scalar) { values ("0.020"); }
+                fall_constraint(scalar) { values ("0.020"); }
+            }
+        }
+        pin(CLKOUT) {
+            direction : output;
+            function  : "(!CLKSEL & CLK1) | (CLKSEL & CLK2)";
+            timing() {
+                related_pin : "CLK1";
+                when        : "!CLKSEL";
+                cell_rise(scalar)       { values ("0.030"); }
+                cell_fall(scalar)       { values ("0.030"); }
+                rise_transition(scalar) { values ("0.020"); }
+                fall_transition(scalar) { values ("0.020"); }
+            }
+            timing() {
+                related_pin : "CLK2";
+                when        : "CLKSEL";
+                cell_rise(scalar)       { values ("0.030"); }
+                cell_fall(scalar)       { values ("0.030"); }
+                rise_transition(scalar) { values ("0.020"); }
+                fall_transition(scalar) { values ("0.020"); }
+            }
+            timing() {
+                related_pin : "CLKSEL";
+                cell_rise(scalar)       { values ("0.025"); }
+                cell_fall(scalar)       { values ("0.025"); }
+                rise_transition(scalar) { values ("0.020"); }
+                fall_transition(scalar) { values ("0.020"); }
+            }
+        }
+    }
+}

--- a/test/non_seq_timing.ok
+++ b/test/non_seq_timing.ok
@@ -1,0 +1,27 @@
+Startpoint: r1 (rising edge-triggered flip-flop clocked by clk)
+Endpoint: ckmux (rising edge-triggered flip-flop clocked by clk)
+Path Group: clk
+Path Type: max
+
+  Delay    Time   Description
+---------------------------------------------------------
+   0.00    0.00   clock clk (rise edge)
+   0.00    0.00   clock network delay (ideal)
+   0.00    0.00 ^ r1/CLK (DFFHQx4_ASAP7_75t_R)
+   0.06    0.06 ^ r1/Q (DFFHQx4_ASAP7_75t_R)
+   0.00    0.06 ^ ckmux/CLKSEL (CKMUX)
+           0.06   data arrival time
+
+  10.00   10.00   clock clk (rise edge)
+   0.00   10.00   clock network delay (ideal)
+   0.00   10.00   clock reconvergence pessimism
+          10.00 ^ ckmux/CLK1 (CKMUX)
+  -0.05    9.95   library non-sequential setup time
+           9.95   data required time
+---------------------------------------------------------
+           9.95   data required time
+          -0.06   data arrival time
+---------------------------------------------------------
+           9.89   slack (MET)
+
+

--- a/test/non_seq_timing.tcl
+++ b/test/non_seq_timing.tcl
@@ -1,0 +1,9 @@
+read_liberty non_seq_timing.lib
+read_liberty asap7_seq.lib.gz
+
+read_verilog non_seq_timing.v
+link_design test
+
+create_clock -name clk -period 10 [get_ports *clk*]
+
+report_checks

--- a/test/non_seq_timing.v
+++ b/test/non_seq_timing.v
@@ -1,0 +1,23 @@
+module test (
+  input  clk1,
+  input  clk2,
+  input  clk3,
+  input  test_en,
+  output out
+);
+
+  wire sel;  
+  DFFHQx4_ASAP7_75t_R r1 (
+    .CLK(clk1),
+    .D(test_en),
+    .Q(sel)
+  );
+
+  CKMUX ckmux (
+    .CLK1  (clk2),
+    .CLK2  (clk3),
+    .CLKSEL(sel),
+    .CLKOUT(out)
+  );
+
+endmodule

--- a/test/regression_vars.tcl
+++ b/test/regression_vars.tcl
@@ -171,6 +171,7 @@ record_public_tests {
   liberty_float_as_str
   liberty_latch3
   liberty_write_escaped_names
+  non_seq_timing
   lib_cell_props
   package_require
   path_group_names


### PR DESCRIPTION
non_seq_setup_rise
non_seq_setup_fall
non_seq_hold_rise
non_seq_hold_fall

not handled properly when populating data structure storing the clock edges to use when reporting timing checks.

leads to the release and capture clock being on the same edge, which is incorrect.

the change allows us to properly handle these timing types