### PR TITLE
Defaulted activity on non-functional pins

### DIFF
--- a/power/Power.cc
+++ b/power/Power.cc
@@ -501,11 +501,10 @@ PropActivityVisitor::visit(Vertex *vertex)
               func = port->function();
           }
         }
-	if (func) {
-          PwrActivity activity = power_->evalActivity(func, inst);
-	  changed = setActivityCheck(pin, activity);
-	}
-        if (port->isClockGateOut()) {
+        if (func) {
+                PwrActivity activity = power_->evalActivity(func, inst);
+          changed = setActivityCheck(pin, activity);
+        } else if (port->isClockGateOut()) {
           const Pin *enable, *clk, *gclk;
           power_->clockGatePins(inst, enable, clk, gclk);
           if (enable && clk && gclk) {
@@ -514,14 +513,20 @@ PropActivityVisitor::visit(Vertex *vertex)
             float p1 = activity1.duty();
             float p2 = activity2.duty();
             PwrActivity activity(activity1.density() * p2 + activity2.density() * p1,
-                                 p1 * p2,
-                                 PwrActivityOrigin::propagated);
+                                p1 * p2,
+                                PwrActivityOrigin::propagated);
             changed = setActivityCheck(gclk, activity);
             debugPrint(debug_, "power_activity", 3, "gated_clk %s %.2e %.2f",
-                       network_->pathName(gclk),
-                       activity.density(),
-                       activity.duty());
+                      network_->pathName(gclk),
+                      activity.density(),
+                      activity.duty());
           }
+        } else {
+                PwrActivity default_act = power_->inputActivity();
+                PwrActivity activity(default_act.density(),
+                                    default_act.duty(),
+                                    PwrActivityOrigin::defaulted);
+          changed = setActivityCheck(pin, activity);
         }
       }
     }

--- a/power/Power.cc
+++ b/power/Power.cc
@@ -501,10 +501,13 @@ PropActivityVisitor::visit(Vertex *vertex)
               func = port->function();
           }
         }
-        if (func) {
-                PwrActivity activity = power_->evalActivity(func, inst);
-          changed = setActivityCheck(pin, activity);
-        } else if (port->isClockGateOut()) {
+  bool annotated = false;
+	if (func) {
+          PwrActivity activity = power_->evalActivity(func, inst);
+	  changed = setActivityCheck(pin, activity);
+    annotated = true;
+	}
+        if (port->isClockGateOut()) {
           const Pin *enable, *clk, *gclk;
           power_->clockGatePins(inst, enable, clk, gclk);
           if (enable && clk && gclk) {
@@ -513,21 +516,23 @@ PropActivityVisitor::visit(Vertex *vertex)
             float p1 = activity1.duty();
             float p2 = activity2.duty();
             PwrActivity activity(activity1.density() * p2 + activity2.density() * p1,
-                                p1 * p2,
-                                PwrActivityOrigin::propagated);
+                                 p1 * p2,
+                                 PwrActivityOrigin::propagated);
             changed = setActivityCheck(gclk, activity);
             debugPrint(debug_, "power_activity", 3, "gated_clk %s %.2e %.2f",
-                      network_->pathName(gclk),
-                      activity.density(),
-                      activity.duty());
+                       network_->pathName(gclk),
+                       activity.density(),
+                       activity.duty());
+            annotated = true;
           }
-        } else {
-                PwrActivity default_act = power_->inputActivity();
-                PwrActivity activity(default_act.density(),
-                                    default_act.duty(),
-                                    PwrActivityOrigin::defaulted);
-          changed = setActivityCheck(pin, activity);
         }
+  if (!annotated) {
+          PwrActivity default_act = power_->inputActivity();
+          PwrActivity activity(default_act.density(),
+                              default_act.duty(),
+                              PwrActivityOrigin::defaulted);
+    changed = setActivityCheck(pin, activity);
+  }
       }
     }
   }

--- a/power/Power.hh
+++ b/power/Power.hh
@@ -109,6 +109,7 @@ public:
   InstanceSeq highestPowerInstances(size_t count,
                                     const Corner *corner);
   void powerInvalid();
+  PwrActivity inputActivity() const { return input_activity_; }
 
 protected:
   PwrActivity &activity(const Pin *pin);


### PR DESCRIPTION
Added boolean to check whether a pin was annotated during visit function on the Activity propagator.

If it was not annotated (by either branch) we will default the activity to the defaults calculated by library/setting from user