### PR TITLE
Smallfix for findActivity

### DIFF
--- a/power/Power.cc
+++ b/power/Power.cc
@@ -1453,6 +1453,8 @@ Power::findActivity(const Pin *pin)
     if (activity.origin() != PwrActivityOrigin::unknown)
       return activity;
   }
+  if (user_activity_map_.hasKey(pin))
+    return user_activity_map_[pin];
   return PwrActivity(0.0, 0.0, PwrActivityOrigin::unknown);
 }
 


### PR DESCRIPTION
Pins specified by the user using set_power_activity are not queried in findActivity because they appear in user_activity_map.  This is not good because some pins can't be propagated through in some cases (flops or macro outputs)

This leads to pins being ignored and reported as having 0 activity/duty when they were actually present as they're set by the user. Before we say an activity origin is unknown, query this map and return the value