### PR TITLE
[ENG-2108] FEATURE - check_setup has json dump option

### DIFF
--- a/include/sta/Sta.hh
+++ b/include/sta/Sta.hh
@@ -966,6 +966,7 @@ public:
                              bool unconstrained_endpoints,
                              bool loops,
                              bool generated_clks);
+  void reportCheckTimingJson(const char *filename);
   // Path from/thrus/to filter.
   // from/thrus/to are owned and deleted by Search.
   // PathEnds in the returned PathEndSeq are owned by Search PathGroups

--- a/search/CheckTiming.cc
+++ b/search/CheckTiming.cc
@@ -74,7 +74,6 @@ CheckTiming::clear()
   deleteErrors();
   errors_.clear();
   json_results_.clear();
-  loop_groups_.clear();
 }
 
 CheckErrorSeq &
@@ -221,13 +220,10 @@ CheckTiming::checkLoops()
 
     for (GraphLoop *loop : loops) {
       if (loop->isCombinational()) {
-        StringSeq loop_pins;
         Edge *last_edge = nullptr;
         for (Edge *edge : *loop->edges()) {
           Pin *pin = edge->from(graph_)->pin();
-          std::string name = sdc_network_->pathName(pin);
-          error->push_back(name);
-          loop_pins.push_back(name);
+          error->push_back(sdc_network_->pathName(pin));
           last_edge = edge;
         }
         if (last_edge) {
@@ -238,7 +234,6 @@ CheckTiming::checkLoops()
           // Separator between loops.
           error->emplace_back("--------------------------------");
         }
-        loop_groups_.push_back(loop_pins);
       }
     }
     errors_.push_back(error);
@@ -431,40 +426,21 @@ CheckTiming::reportJson(const char *filename) const
     throw FileNotWritable(filename);
 
   stream << "{\n";
-  bool first = true;
-  for (const std::pair<std::string, StringSeq> &result : json_results_) {
-    if (!first)
-      stream << ",\n";
-    first = false;
-    const StringSeq &names = result.second;
-    stream << "  \"" << result.first << "\": [";
+  size_t n = json_results_.size();
+  for (size_t i = 0; i < n; i++) {
+    const std::string &key = json_results_[i].first;
+    const StringSeq &names = json_results_[i].second;
+    stream << "  \"" << key << "\": [";
     for (size_t j = 0; j < names.size(); j++) {
       if (j != 0)
         stream << ", ";
       stream << "\"" << jsonEscape(names[j]) << "\"";
     }
     stream << "]";
+    if (i + 1 < n)
+      stream << ",";
+    stream << "\n";
   }
-  // Loops are an array of arrays: one pin list per loop.
-  if (!loop_groups_.empty()) {
-    if (!first)
-      stream << ",\n";
-    stream << "  \"combinational_loop\": [";
-    for (size_t i = 0; i < loop_groups_.size(); i++) {
-      if (i != 0)
-        stream << ", ";
-      const StringSeq &loop = loop_groups_[i];
-      stream << "[";
-      for (size_t j = 0; j < loop.size(); j++) {
-        if (j != 0)
-          stream << ", ";
-        stream << "\"" << jsonEscape(loop[j]) << "\"";
-      }
-      stream << "]";
-    }
-    stream << "]";
-  }
-  stream << "\n";
   stream << "}\n";
 }
 

--- a/search/CheckTiming.cc
+++ b/search/CheckTiming.cc
@@ -24,7 +24,11 @@
 
 #include "CheckTiming.hh"
 
+#include <fstream>
+#include <string>
+
 #include "ClkNetwork.hh"
+#include "Error.hh"
 #include "ExceptionPath.hh"
 #include "Format.hh"
 #include "Genclks.hh"
@@ -69,6 +73,7 @@ CheckTiming::clear()
 {
   deleteErrors();
   errors_.clear();
+  json_results_.clear();
 }
 
 CheckErrorSeq &
@@ -120,7 +125,8 @@ CheckTiming::checkNoInputDelay()
     }
   }
   delete pin_iter;
-  pushPinErrors("Warning: There {} {} input port{} missing set_input_delay.",no_arrival);
+  pushPinErrors("Warning: There {} {} input port{} missing set_input_delay.",
+                "no_input_delay", no_arrival);
 }
 
 void
@@ -129,7 +135,7 @@ CheckTiming::checkNoOutputDelay()
   PinSet no_departure(network_);
   checkNoOutputDelay(no_departure);
   pushPinErrors("Warning: There {} {} output port{} missing set_output_delay.",
-                no_departure);
+                "no_output_delay", no_departure);
 }
 
 void
@@ -176,9 +182,9 @@ CheckTiming::checkRegClks(bool reg_multiple_clks,
       multiple_clk_pins.insert(pin);
   }
   pushPinErrors("Warning: There {} {} unclocked register/latch pin{}.",
-                no_clk_pins);
+                "unclocked", no_clk_pins);
   pushPinErrors("Warning: There {} {} register/latch pin{} with multiple clocks.",
-                multiple_clk_pins);
+                "multiple_clock", multiple_clk_pins);
 }
 
 static const char *
@@ -231,6 +237,7 @@ CheckTiming::checkLoops()
       }
     }
     errors_.push_back(error);
+    json_results_.emplace_back("combinational_loop", StringSeq(error->begin() + 1, error->end()));
   }
 }
 
@@ -241,7 +248,7 @@ CheckTiming::checkUnconstrainedEndpoints()
   checkUnconstrainedOutputs(unconstrained_ends);
   checkUnconstrainedSetups(unconstrained_ends);
   pushPinErrors("Warning: There {} {} unconstrained endpoint{}.",
-                unconstrained_ends);
+                "unconstrained", unconstrained_ends);
 }
 
 void
@@ -347,12 +354,13 @@ CheckTiming::checkGeneratedClocks()
     }
   }
   pushClkErrors("Warning: There {} {} generated clock{} not connected to a clock source.",
-                gen_clk_errors);
+                "generated_clock", gen_clk_errors);
 }
 
 // Report the "msg" error for each pin in "pins".
 void
 CheckTiming::pushPinErrors(std::string_view msg,
+                           const char *json_key,
                            PinSet &pins)
 {
   if (!pins.empty()) {
@@ -368,11 +376,13 @@ CheckTiming::pushPinErrors(std::string_view msg,
       error->push_back(sdc_network_->pathName(pin));
     }
     errors_.push_back(error);
+    json_results_.emplace_back(json_key, StringSeq(error->begin() + 1, error->end()));
   }
 }
 
 void
 CheckTiming::pushClkErrors(const char *msg,
+                           const char *json_key,
                            ClockSet &clks)
 {
   if (!clks.empty()) {
@@ -388,7 +398,51 @@ CheckTiming::pushClkErrors(const char *msg,
       error->push_back(clk->name());
     }
     errors_.push_back(error);
+    json_results_.emplace_back(json_key, StringSeq(error->begin() + 1, error->end()));
   }
+}
+
+static std::string
+jsonEscape(const std::string &s)
+{
+  std::string out;
+  for (char c : s) {
+    switch (c) {
+    case '"':  out += "\\\""; break;
+    case '\\': out += "\\\\"; break;
+    case '\n': out += "\\n";  break;
+    case '\t': out += "\\t";  break;
+    case '\r': out += "\\r";  break;
+    default:   out += c;
+    }
+  }
+  return out;
+}
+
+void
+CheckTiming::reportJson(const char *filename) const
+{
+  std::ofstream stream(filename);
+  if (!stream.is_open())
+    throw FileNotWritable(filename);
+
+  stream << "{\n";
+  size_t n = json_results_.size();
+  for (size_t i = 0; i < n; i++) {
+    const std::string &key = json_results_[i].first;
+    const StringSeq &names = json_results_[i].second;
+    stream << "  \"" << key << "\": [";
+    for (size_t j = 0; j < names.size(); j++) {
+      stream << "\"" << jsonEscape(names[j]) << "\"";
+      if (j + 1 < names.size())
+        stream << ", ";
+    }
+    stream << "]";
+    if (i + 1 < n)
+      stream << ",";
+    stream << "\n";
+  }
+  stream << "}\n";
 }
 
 } // namespace sta

--- a/search/CheckTiming.cc
+++ b/search/CheckTiming.cc
@@ -432,10 +432,12 @@ CheckTiming::reportJson(const char *filename) const
     const StringSeq &names = json_results_[i].second;
     stream << "  \"" << key << "\": [";
     for (size_t j = 0; j < names.size(); j++) {
-      if (j != 0)
-        stream << ", ";
-      stream << "\"" << jsonEscape(names[j]) << "\"";
+      stream << "\n    \"" << jsonEscape(names[j]) << "\"";
+      if (j + 1 < names.size())
+        stream << ",";
     }
+    if (!names.empty())
+      stream << "\n  ";
     stream << "]";
     if (i + 1 < n)
       stream << ",";

--- a/search/CheckTiming.cc
+++ b/search/CheckTiming.cc
@@ -74,6 +74,7 @@ CheckTiming::clear()
   deleteErrors();
   errors_.clear();
   json_results_.clear();
+  loop_groups_.clear();
 }
 
 CheckErrorSeq &
@@ -220,10 +221,13 @@ CheckTiming::checkLoops()
 
     for (GraphLoop *loop : loops) {
       if (loop->isCombinational()) {
+        StringSeq loop_pins;
         Edge *last_edge = nullptr;
         for (Edge *edge : *loop->edges()) {
           Pin *pin = edge->from(graph_)->pin();
-          error->push_back(sdc_network_->pathName(pin));
+          std::string name = sdc_network_->pathName(pin);
+          error->push_back(name);
+          loop_pins.push_back(name);
           last_edge = edge;
         }
         if (last_edge) {
@@ -234,10 +238,10 @@ CheckTiming::checkLoops()
           // Separator between loops.
           error->emplace_back("--------------------------------");
         }
+        loop_groups_.push_back(loop_pins);
       }
     }
     errors_.push_back(error);
-    json_results_.emplace_back("combinational_loop", StringSeq(error->begin() + 1, error->end()));
   }
 }
 
@@ -427,21 +431,40 @@ CheckTiming::reportJson(const char *filename) const
     throw FileNotWritable(filename);
 
   stream << "{\n";
-  size_t n = json_results_.size();
-  for (size_t i = 0; i < n; i++) {
-    const std::string &key = json_results_[i].first;
-    const StringSeq &names = json_results_[i].second;
-    stream << "  \"" << key << "\": [";
+  bool first = true;
+  for (const std::pair<std::string, StringSeq> &result : json_results_) {
+    if (!first)
+      stream << ",\n";
+    first = false;
+    const StringSeq &names = result.second;
+    stream << "  \"" << result.first << "\": [";
     for (size_t j = 0; j < names.size(); j++) {
-      stream << "\"" << jsonEscape(names[j]) << "\"";
-      if (j + 1 < names.size())
+      if (j != 0)
         stream << ", ";
+      stream << "\"" << jsonEscape(names[j]) << "\"";
     }
     stream << "]";
-    if (i + 1 < n)
-      stream << ",";
-    stream << "\n";
   }
+  // Loops are an array of arrays: one pin list per loop.
+  if (!loop_groups_.empty()) {
+    if (!first)
+      stream << ",\n";
+    stream << "  \"combinational_loop\": [";
+    for (size_t i = 0; i < loop_groups_.size(); i++) {
+      if (i != 0)
+        stream << ", ";
+      const StringSeq &loop = loop_groups_[i];
+      stream << "[";
+      for (size_t j = 0; j < loop.size(); j++) {
+        if (j != 0)
+          stream << ", ";
+        stream << "\"" << jsonEscape(loop[j]) << "\"";
+      }
+      stream << "]";
+    }
+    stream << "]";
+  }
+  stream << "\n";
   stream << "}\n";
 }
 

--- a/search/CheckTiming.cc
+++ b/search/CheckTiming.cc
@@ -409,9 +409,6 @@ jsonEscape(const std::string &s)
     switch (c) {
     case '"':  out += "\\\""; break;
     case '\\': out += "\\\\"; break;
-    case '\n': out += "\\n";  break;
-    case '\t': out += "\\t";  break;
-    case '\r': out += "\\r";  break;
     default:   out += c;
     }
   }
@@ -425,6 +422,7 @@ CheckTiming::reportJson(const char *filename) const
   if (!stream.is_open())
     throw FileNotWritable(filename);
 
+  // Start JSON object.
   stream << "{\n";
   size_t n = json_results_.size();
   for (size_t i = 0; i < n; i++) {
@@ -433,16 +431,20 @@ CheckTiming::reportJson(const char *filename) const
     stream << "  \"" << key << "\": [";
     for (size_t j = 0; j < names.size(); j++) {
       stream << "\n    \"" << jsonEscape(names[j]) << "\"";
+      // Comma between elements only; the last element must not be followed by one.
       if (j + 1 < names.size())
         stream << ",";
     }
+    // Close the array on its own indented line when it has contents.
     if (!names.empty())
       stream << "\n  ";
     stream << "]";
+    // Trailing commas are invalid JSON.
     if (i + 1 < n)
       stream << ",";
     stream << "\n";
   }
+  // Close JSON object.
   stream << "}\n";
 }
 

--- a/search/CheckTiming.hh
+++ b/search/CheckTiming.hh
@@ -24,7 +24,9 @@
 
 #pragma once
 
+#include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "GraphClass.hh"
@@ -54,6 +56,7 @@ public:
                        bool unconstrained_endpoints,
                        bool loops,
                        bool generated_clks);
+  void reportJson(const char *filename) const;
 
 protected:
   void clear();
@@ -73,11 +76,14 @@ protected:
   bool hasMaxDelay(Pin *pin);
   void checkGeneratedClocks();
   void pushPinErrors(std::string_view msg,
+                     const char *json_key,
                      PinSet &pins);
   void pushClkErrors(const char *msg,
+                     const char *json_key,
                      ClockSet &clks);
 
   CheckErrorSeq errors_;
+  std::vector<std::pair<std::string, StringSeq>> json_results_;
   const Mode *mode_{nullptr};
   const Sdc *sdc_{nullptr};
   const Sim *sim_{nullptr};

--- a/search/CheckTiming.hh
+++ b/search/CheckTiming.hh
@@ -84,7 +84,6 @@ protected:
 
   CheckErrorSeq errors_;
   std::vector<std::pair<std::string, StringSeq>> json_results_;
-  std::vector<StringSeq> loop_groups_;
   const Mode *mode_{nullptr};
   const Sdc *sdc_{nullptr};
   const Sim *sim_{nullptr};

--- a/search/CheckTiming.hh
+++ b/search/CheckTiming.hh
@@ -84,6 +84,7 @@ protected:
 
   CheckErrorSeq errors_;
   std::vector<std::pair<std::string, StringSeq>> json_results_;
+  std::vector<StringSeq> loop_groups_;
   const Mode *mode_{nullptr};
   const Sdc *sdc_{nullptr};
   const Sim *sim_{nullptr};

--- a/search/Search.i
+++ b/search/Search.i
@@ -906,6 +906,12 @@ check_timing_cmd(bool no_input_delay,
                           loops, generated_clks);
 }
 
+void
+report_check_timing_json(const char *filename)
+{
+  Sta::sta()->reportCheckTimingJson(filename);
+}
+
 ////////////////////////////////////////////////////////////////
 
 PinSet

--- a/search/Search.tcl
+++ b/search/Search.tcl
@@ -34,14 +34,14 @@ define_cmd_args "check_setup" \
   { [-verbose] [-no_input_delay] [-no_output_delay]\
       [-multiple_clock] [-no_clock]\
       [-unconstrained_endpoints] [-loops] [-generated_clocks]\
-      [> filename] [>> filename] }
+      [-json filename] [> filename] [>> filename] }
 
 proc_redirect check_setup {
   check_setup_cmd "check_setup" $args
 }
 
 proc check_setup_cmd { cmd cmd_args } {
-  parse_key_args $cmd cmd_args keys {} flags {-verbose} 0
+  parse_key_args $cmd cmd_args keys {-json} flags {-verbose} 0
   # When nothing is everything.
   if { $cmd_args == {} } {
     set unconstrained_endpoints 1
@@ -76,6 +76,12 @@ proc check_setup_cmd { cmd cmd_args } {
         report_line "  $obj"
       }
     }
+  }
+  if { [info exists keys(-json)] } {
+    if { $keys(-json) == "" } {
+      sta_error 517 "$cmd -json requires am output file location."
+    }
+    report_check_timing_json $keys(-json)
   }
   # return value
   expr [llength $errors] == 0

--- a/search/Search.tcl
+++ b/search/Search.tcl
@@ -79,7 +79,7 @@ proc check_setup_cmd { cmd cmd_args } {
   }
   if { [info exists keys(-json)] } {
     if { $keys(-json) == "" } {
-      sta_error 517 "$cmd -json requires am output file location."
+      sta_error 517 "$cmd -json requires an output file location."
     }
     if { $loops } {
       sta_warn 518 "$cmd -json does not support -loops. Loops are not emitted."

--- a/search/Search.tcl
+++ b/search/Search.tcl
@@ -81,6 +81,9 @@ proc check_setup_cmd { cmd cmd_args } {
     if { $keys(-json) == "" } {
       sta_error 517 "$cmd -json requires am output file location."
     }
+    if { $loops } {
+      sta_warn 518 "$cmd -json does not support -loops. Loops are not emitted."
+    }
     report_check_timing_json $keys(-json)
   }
   # return value

--- a/search/Sta.cc
+++ b/search/Sta.cc
@@ -2294,6 +2294,12 @@ Sta::checkTiming(const Mode *mode,
                               unconstrained_endpoints, loops, generated_clks);
 }
 
+void
+Sta::reportCheckTimingJson(const char *filename)
+{
+  check_timing_->reportJson(filename);
+}
+
 ////////////////////////////////////////////////////////////////
 
 bool

--- a/test/check_setup_json.ok
+++ b/test/check_setup_json.ok
@@ -1,0 +1,22 @@
+Warning: There are 4 input ports missing set_input_delay.
+Warning: There are 2 unclocked register/latch pins.
+Warning: There are 4 unconstrained endpoints.
+Warning 518: check_setup_json.tcl line 16, check_setup -json does not support -loops. Loops are not emitted.
+{
+  "no_input_delay": [
+    "clk2",
+    "clk3",
+    "in1",
+    "in2"
+  ],
+  "unclocked": [
+    "r2/CLK",
+    "r3/CLK"
+  ],
+  "unconstrained": [
+    "out",
+    "r1/D",
+    "r2/D",
+    "r3/D"
+  ]
+}

--- a/test/check_setup_json.tcl
+++ b/test/check_setup_json.tcl
@@ -1,0 +1,18 @@
+# check_setup -json
+source helpers.tcl
+read_liberty asap7_small.lib.gz
+read_verilog reg1_asap7.v
+link_design top
+
+# Only constrain clk1; leave clk2/clk3, inputs, and outputs unconstrained
+create_clock -name clk1 -period 500 clk1
+
+set json_file [make_result_file "check_setup_json.json"]
+
+# Dump JSON, should warn that loops aren't supported.
+check_setup -unconstrained_endpoints -multiple_clock -no_clock \
+            -no_input_delay -generated_clocks \
+            -loop \
+            -json $json_file
+
+report_file $json_file

--- a/test/regression_vars.tcl
+++ b/test/regression_vars.tcl
@@ -142,6 +142,7 @@ record_example_tests {
 
 record_public_tests {
   collections
+  check_setup_json
   delay_calc_no_inv
   disable_clock_gating_check
   disconnect_mcp_pin


### PR DESCRIPTION
Added a "-json [filepath]" option to the check_setup command to dump a comprehensive JSON summary that would normally go to a report

Implementation consists of these main parts:
1. data structure stores pins for each category (unconstrained, unclocked, no_input_delay, etc) as we collect these warnings
2. if -json is specified we will call the C++ json dumper
3. tcl frontend checks that there is a filename arg and warns that -loop will not be dumped in json output

Test case provided for validation purposes

**NOTE - loops are not dumped for now because of more overhead in implementation + we don't use it right now**