### PR TITLE
[ENG-2404], .libdb creation and read

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,8 @@ set(STA_SOURCE
   liberty/GeneratedClock.cc
   liberty/InternalPower.cc
   liberty/LeakagePower.cc
+  liberty/LibDbReader.cc
+  liberty/LibDbWriter.cc
   liberty/Liberty.cc
   liberty/LibertyBuilder.cc
   liberty/LibExprReader.cc

--- a/include/sta/Sta.hh
+++ b/include/sta/Sta.hh
@@ -152,6 +152,12 @@ public:
                                       Scene *scene,
                                       const MinMaxAll *min_max,
                                       bool infer_latches);
+  // Compiled NLDM-only form of readLiberty
+  virtual LibertyLibrary *readLibDb(std::string_view filename,
+                                    Scene *scene,
+                                    const MinMaxAll *min_max);
+  void writeLibDb(LibertyLibrary *library,
+                  std::string_view filename);
   // tmp public
   void readLibertyAfter(LibertyLibrary *liberty,
                         Scene *scene,

--- a/include/sta/Sta.hh
+++ b/include/sta/Sta.hh
@@ -153,9 +153,7 @@ public:
                                       const MinMaxAll *min_max,
                                       bool infer_latches);
   // Compiled NLDM-only form of readLiberty
-  virtual LibertyLibrary *readLibDb(std::string_view filename,
-                                    Scene *scene,
-                                    const MinMaxAll *min_max);
+  virtual LibertyLibrary *readLibDb(std::string_view filename);
   void writeLibDb(LibertyLibrary *library,
                   std::string_view filename);
   // tmp public

--- a/liberty/LibDb.hh
+++ b/liberty/LibDb.hh
@@ -1,0 +1,207 @@
+// OpenSTA, Static Timing Analyzer
+// Copyright (c) 2026, Parallax Software, Inc.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+// 
+// The origin of this software must not be misrepresented; you must not
+// claim that you wrote the original software.
+// 
+// Altered source versions must be plainly marked as such, and must not be
+// misrepresented as being the original software.
+// 
+// This notice may not be removed or altered from any source distribution.
+
+// Binary liberty database (.libdb).
+//
+// Compiles the timing-relevant subset of a liberty library into a binary form
+// that reloads without running the liberty parser. Reconstruction goes through
+// LibertyBuilder and the public setters, so a loaded library is an ordinary
+// LibertyLibrary with no special-cased behaviour downstream.
+//
+// Scope: NLDM timing only. CCS, LVF/POCV and power groups are intentionally
+// not stored; see kFlagHasCcs/kFlagHasLvf below.
+
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <map>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace sta {
+
+class LibertyLibrary;
+class Network;
+class Report;
+
+// Bumped whenever the on-disk layout changes. Readers reject any other value
+// rather than trying to interpret an older layout.
+constexpr uint32_t kLibDbVersion = 1;
+constexpr char kLibDbMagic[8] = {'S', 'T', 'A', 'L', 'I', 'B', 'D', 'B'};
+
+// Capability bits. All are 0 today; they exist so a future writer can add CCS
+// or LVF without a version bump, and so the engine can refuse delay
+// calculators that would silently fall back to NLDM.
+constexpr uint32_t kFlagHasCcs = 1u << 0;
+constexpr uint32_t kFlagHasLvf = 1u << 1;
+constexpr uint32_t kFlagHasPower = 1u << 2;
+
+struct LibDbHeader
+{
+  char magic[8];
+  uint32_t version;
+  uint32_t flags;
+  // infer_latches changes which timing arcs finish() creates, so a db compiled
+  // with it set is not interchangeable with one compiled without.
+  uint32_t infer_latches;
+  uint32_t pointer_size;
+  uint64_t string_bytes;
+  uint64_t body_bytes;
+};
+
+// Serialization uses native byte order and native float layout; the header
+// records pointer size and the reader validates it. Databases are portable
+// between machines of the same architecture, which is the stated scope.
+
+class DbWriter
+{
+public:
+  void u8(uint8_t v) { raw(&v, sizeof v); }
+  void u32(uint32_t v) { raw(&v, sizeof v); }
+  void u64(uint64_t v) { raw(&v, sizeof v); }
+  void i32(int32_t v) { raw(&v, sizeof v); }
+  void f32(float v) { raw(&v, sizeof v); }
+  void boolean(bool v) { u8(v ? 1 : 0); }
+
+  void floats(const std::vector<float> &v)
+  {
+    u32(static_cast<uint32_t>(v.size()));
+    if (!v.empty())
+      raw(v.data(), v.size() * sizeof(float));
+  }
+
+  // Strings are stored once in a side table and referenced by index, which
+  // matters because cell and port names repeat heavily across a library.
+  void str(std::string_view s) { u32(internString(s)); }
+
+  uint32_t internString(std::string_view s)
+  {
+    auto [it, inserted] = string_ids_.try_emplace(std::string(s),
+                                                  static_cast<uint32_t>(strings_.size()));
+    if (inserted)
+      strings_.push_back(std::string(s));
+    return it->second;
+  }
+
+  const std::vector<std::string> &strings() const { return strings_; }
+  const std::vector<uint8_t> &bytes() const { return buf_; }
+  size_t size() const { return buf_.size(); }
+
+private:
+  void raw(const void *p, size_t n)
+  {
+    const uint8_t *b = static_cast<const uint8_t *>(p);
+    buf_.insert(buf_.end(), b, b + n);
+  }
+
+  std::vector<uint8_t> buf_;
+  std::vector<std::string> strings_;
+  std::map<std::string, uint32_t, std::less<>> string_ids_;
+};
+
+class DbReader
+{
+public:
+  DbReader(const uint8_t *data,
+           size_t size,
+           const std::vector<std::string> *strings) :
+    data_(data),
+    size_(size),
+    strings_(strings)
+  {
+  }
+
+  uint8_t u8() { return read<uint8_t>(); }
+  uint32_t u32() { return read<uint32_t>(); }
+  uint64_t u64() { return read<uint64_t>(); }
+  int32_t i32() { return read<int32_t>(); }
+  float f32() { return read<float>(); }
+  bool boolean() { return u8() != 0; }
+
+  std::vector<float> floats()
+  {
+    uint32_t n = u32();
+    std::vector<float> v(n);
+    if (n && ok(n * sizeof(float))) {
+      std::memcpy(v.data(), data_ + pos_, n * sizeof(float));
+      pos_ += n * sizeof(float);
+    }
+    return v;
+  }
+
+  const std::string &str()
+  {
+    uint32_t id = u32();
+    if (id >= strings_->size()) {
+      fail();
+      static const std::string empty;
+      return empty;
+    }
+    return (*strings_)[id];
+  }
+
+  bool failed() const { return failed_; }
+
+private:
+  template <typename T>
+  T read()
+  {
+    T v{};
+    if (ok(sizeof(T))) {
+      std::memcpy(&v, data_ + pos_, sizeof(T));
+      pos_ += sizeof(T);
+    }
+    return v;
+  }
+
+  bool ok(size_t n)
+  {
+    if (pos_ + n > size_) {
+      fail();
+      return false;
+    }
+    return true;
+  }
+
+  void fail() { failed_ = true; }
+
+  const uint8_t *data_;
+  size_t size_;
+  size_t pos_{0};
+  const std::vector<std::string> *strings_;
+  bool failed_{false};
+};
+
+// Compile an already loaded liberty library to filename.
+void writeLibDbFile(LibertyLibrary *library,
+                    std::string_view filename,
+                    Report *report);
+
+// Rebuild a liberty library from filename and register it with network.
+LibertyLibrary *readLibDbFile(std::string_view filename,
+                              Network *network);
+
+} // namespace sta

--- a/liberty/LibDb.hh
+++ b/liberty/LibDb.hh
@@ -21,16 +21,8 @@
 // misrepresented as being the original software.
 // 
 // This notice may not be removed or altered from any source distribution.
-
 // Binary liberty database (.libdb).
-//
-// Compiles the timing-relevant subset of a liberty library into a binary form
-// that reloads without running the liberty parser. Reconstruction goes through
-// LibertyBuilder and the public setters, so a loaded library is an ordinary
-// LibertyLibrary with no special-cased behaviour downstream.
-//
-// Scope: NLDM timing only. CCS, LVF/POCV and power groups are intentionally
-// not stored; see kFlagHasCcs/kFlagHasLvf below.
+// Filename must end in .libdb and works across machines of the same architecture.
 
 #pragma once
 
@@ -47,35 +39,24 @@ class LibertyLibrary;
 class Network;
 class Report;
 
-// Bumped whenever the on-disk layout changes. Readers reject any other value
-// rather than trying to interpret an older layout.
-constexpr uint32_t kLibDbVersion = 1;
-constexpr char kLibDbMagic[8] = {'S', 'T', 'A', 'L', 'I', 'B', 'D', 'B'};
+// Bumped when the on-disk layout changes; readers reject any other value.
+constexpr uint32_t lib_db_version = 1;
+// Means "no object here" for shared axes/tables/attrs ids.
+constexpr uint32_t lib_db_id_null = 0xFFFFFFFFu;
 
-// Capability bits. All are 0 today; they exist so a future writer can add CCS
-// or LVF without a version bump, and so the engine can refuse delay
-// calculators that would silently fall back to NLDM.
-constexpr uint32_t kFlagHasCcs = 1u << 0;
-constexpr uint32_t kFlagHasLvf = 1u << 1;
-constexpr uint32_t kFlagHasPower = 1u << 2;
+enum class LibDbModelKind : uint8_t { none = 0, gate = 1, check = 2 };
+enum class LibDbPortKind : uint8_t { scalar = 0, bus = 1, bundle = 2 };
 
+// Header for the libdb file.
 struct LibDbHeader
 {
-  char magic[8];
-  uint32_t version;
-  uint32_t flags;
-  // infer_latches changes which timing arcs finish() creates, so a db compiled
-  // with it set is not interchangeable with one compiled without.
-  uint32_t infer_latches;
-  uint32_t pointer_size;
-  uint64_t string_bytes;
-  uint64_t body_bytes;
+  uint32_t version;      // version of the libdb format
+  uint64_t string_bytes; // bytes of serialized strings
+  uint64_t body_bytes;   // bytes of serialized body
 };
 
-// Serialization uses native byte order and native float layout; the header
-// records pointer size and the reader validates it. Databases are portable
-// between machines of the same architecture, which is the stated scope.
-
+// Builds the file body as a growing byte list. Also keeps a list of unique
+// strings so names are stored once and referenced by a small number.
 class DbWriter
 {
 public:
@@ -86,6 +67,7 @@ public:
   void f32(float v) { raw(&v, sizeof v); }
   void boolean(bool v) { u8(v ? 1 : 0); }
 
+  // Length-prefixed float array: u32 count, then count floats.
   void floats(const std::vector<float> &v)
   {
     u32(static_cast<uint32_t>(v.size()));
@@ -93,10 +75,11 @@ public:
       raw(v.data(), v.size() * sizeof(float));
   }
 
-  // Strings are stored once in a side table and referenced by index, which
-  // matters because cell and port names repeat heavily across a library.
+  // Write a number that points into the unique-string list (not the text).
   void str(std::string_view s) { u32(internString(s)); }
 
+  // If we have not seen this string before, add it and give it a new number.
+  // If we have, return the same number again.
   uint32_t internString(std::string_view s)
   {
     auto [it, inserted] = string_ids_.try_emplace(std::string(s),
@@ -122,6 +105,18 @@ private:
   std::map<std::string, uint32_t, std::less<>> string_ids_;
 };
 
+// Reads the body left-to-right, like a bookmark moving through a byte array:
+//
+//   data_[0 .. size_)  = whole body
+//   pos_               = next byte to read (starts at 0, moves forward)
+//
+// u32()/f32()/... call read<T>(), which:
+//   1) ok(sizeof(T)) — enough bytes left? if not, fail() and return 0
+//   2) copy those bytes into a value
+//   3) pos_ += sizeof(T)
+//
+// str() reads a u32 id, then looks up strings_[id] (the side string list).
+// At the end of the library load, LibLoader checks failed().
 class DbReader
 {
 public:
@@ -134,6 +129,7 @@ public:
   {
   }
 
+  // Each of these advances pos_ by the size of that type.
   uint8_t u8() { return read<uint8_t>(); }
   uint32_t u32() { return read<uint32_t>(); }
   uint64_t u64() { return read<uint64_t>(); }
@@ -141,6 +137,7 @@ public:
   float f32() { return read<float>(); }
   bool boolean() { return u8() != 0; }
 
+  // count (u32), then that many floats in a row.
   std::vector<float> floats()
   {
     uint32_t n = u32();
@@ -152,6 +149,7 @@ public:
     return v;
   }
 
+  // Read string-list index, return that string (or empty if bad id).
   const std::string &str()
   {
     uint32_t id = u32();
@@ -166,6 +164,7 @@ public:
   bool failed() const { return failed_; }
 
 private:
+  // Copy the next sizeof(T) bytes at pos_ into a T and slide the bookmark.
   template <typename T>
   T read()
   {
@@ -177,6 +176,7 @@ private:
     return v;
   }
 
+  // True if n more bytes fit before size_. On failure, mark failed_.
   bool ok(size_t n)
   {
     if (pos_ + n > size_) {
@@ -188,11 +188,11 @@ private:
 
   void fail() { failed_ = true; }
 
-  const uint8_t *data_;
-  size_t size_;
-  size_t pos_{0};
-  const std::vector<std::string> *strings_;
-  bool failed_{false};
+  const uint8_t *data_;   // body start
+  size_t size_;           // body length in bytes
+  size_t pos_{0};         // bookmark: next unread byte
+  const std::vector<std::string> *strings_;  // side string list
+  bool failed_{false};    // true if we read past the end or bad string id
 };
 
 // Compile an already loaded liberty library to filename.

--- a/liberty/LibDbReader.cc
+++ b/liberty/LibDbReader.cc
@@ -1,0 +1,802 @@
+// OpenSTA, Static Timing Analyzer
+// Copyright (c) 2026, Parallax Software, Inc.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+// 
+// The origin of this software must not be misrepresented; you must not
+// claim that you wrote the original software.
+// 
+// Altered source versions must be plainly marked as such, and must not be
+// misrepresented as being the original software.
+// 
+// This notice may not be removed or altered from any source distribution.
+
+#include "LibDb.hh"
+
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "ConcreteLibrary.hh"
+#include "Debug.hh"
+#include "FuncExpr.hh"
+#include "Liberty.hh"
+#include "LibertyBuilder.hh"
+#include "Network.hh"
+#include "PortDirection.hh"
+#include "Report.hh"
+#include "Sequential.hh"
+#include "TableModel.hh"
+#include "TimingArc.hh"
+#include "TimingModel.hh"
+#include "TimingRole.hh"
+#include "Transition.hh"
+#include "Units.hh"
+
+namespace sta {
+
+namespace {
+
+constexpr uint32_t kNullId = 0xFFFFFFFFu;
+
+enum class ModelKind : uint8_t { none = 0, gate = 1, check = 2 };
+enum class PortKind : uint8_t { scalar = 0, bus = 1, bundle = 2 };
+
+PortDirection *
+directionFromCode(uint8_t code)
+{
+  switch (code) {
+  case 0: return PortDirection::input();
+  case 1: return PortDirection::output();
+  case 2: return PortDirection::tristate();
+  case 3: return PortDirection::bidirect();
+  case 4: return PortDirection::internal();
+  case 5: return PortDirection::ground();
+  case 6: return PortDirection::power();
+  case 7: return PortDirection::well();
+  default: return PortDirection::unknown();
+  }
+}
+
+class LibLoader
+{
+public:
+  LibLoader(DbReader &r,
+            std::string_view filename,
+            Network *network,
+            bool infer_latches) :
+    r_(r),
+    filename_(filename),
+    network_(network),
+    report_(network->report()),
+    debug_(network->debug()),
+    builder_(network->debug(), network->report()),
+    infer_latches_(infer_latches)
+  {
+  }
+
+  LibertyLibrary *read();
+
+private:
+  void readUnit(Unit *unit);
+  void readCell();
+  void readPort(LibertyCell *cell);
+  void readPortAttrs(LibertyCell *cell);
+  FuncExpr *readFuncExpr(LibertyCell *cell);
+  void readArcSet(LibertyCell *cell);
+  TimingArcAttrsPtr readAttrs(LibertyCell *cell);
+  TimingModel *readModel(LibertyCell *cell);
+  TableModels *readTableModels();
+  TableModel *readTableModel();
+  TablePtr readTableRef();
+  TableAxisPtr readAxisRef();
+  LibertyPort *readPortRef(LibertyCell *cell);
+
+  DbReader &r_;
+  std::string filename_;
+  Network *network_;
+  Report *report_;
+  Debug *debug_;
+  LibertyBuilder builder_;
+  bool infer_latches_;
+  LibertyLibrary *lib_{nullptr};
+
+  std::vector<TableAxisPtr> axes_;
+  std::vector<TablePtr> tables_;
+  std::vector<TimingArcAttrsPtr> attrs_;
+};
+
+////////////////////////////////////////////////////////////////
+// Interned references. An id at or past the end of the table means the
+// definition follows inline, mirroring the writer.
+
+LibertyPort *
+LibLoader::readPortRef(LibertyCell *cell)
+{
+  if (!r_.boolean())
+    return nullptr;
+  const std::string &name = r_.str();
+  return cell ? cell->findLibertyPort(name) : nullptr;
+}
+
+TableAxisPtr
+LibLoader::readAxisRef()
+{
+  uint32_t id = r_.u32();
+  if (id == kNullId)
+    return nullptr;
+  if (id < axes_.size())
+    return axes_[id];
+
+  TableAxisVariable var = static_cast<TableAxisVariable>(r_.u8());
+  FloatSeq values = r_.floats();
+  TableAxisPtr axis = std::make_shared<TableAxis>(var, std::move(values));
+  axes_.push_back(axis);
+  return axis;
+}
+
+TablePtr
+LibLoader::readTableRef()
+{
+  uint32_t id = r_.u32();
+  if (id == kNullId)
+    return nullptr;
+  if (id < tables_.size())
+    return tables_[id];
+
+  int order = r_.u8();
+  TableAxisPtr axis1 = readAxisRef();
+  TableAxisPtr axis2 = readAxisRef();
+  TableAxisPtr axis3 = readAxisRef();
+
+  TablePtr table;
+  if (order == 0)
+    table = std::make_shared<Table>(r_.f32());
+  else if (order == 1)
+    table = std::make_shared<Table>(r_.floats(), axis1);
+  else {
+    uint32_t rows = r_.u32();
+    FloatTable values;
+    values.reserve(rows);
+    for (uint32_t i = 0; i < rows; i++)
+      values.push_back(r_.floats());
+    if (order == 2)
+      table = std::make_shared<Table>(std::move(values), axis1, axis2);
+    else
+      table = std::make_shared<Table>(std::move(values), axis1, axis2, axis3);
+  }
+  tables_.push_back(table);
+  return table;
+}
+
+////////////////////////////////////////////////////////////////
+
+TableModel *
+LibLoader::readTableModel()
+{
+  if (!r_.boolean())
+    return nullptr;
+  TablePtr table = readTableRef();
+  TableTemplate *tmpl = nullptr;
+  if (r_.boolean()) {
+    const std::string &name = r_.str();
+    TableTemplateType type = static_cast<TableTemplateType>(r_.u8());
+    tmpl = lib_->findTableTemplate(name, type);
+  }
+  ScaleFactorType sf_type = static_cast<ScaleFactorType>(r_.u8());
+  const RiseFall *rf = RiseFall::find(static_cast<size_t>(r_.u8()));
+  return new TableModel(table, tmpl, sf_type, rf);
+}
+
+TableModels *
+LibLoader::readTableModels()
+{
+  if (!r_.boolean())
+    return nullptr;
+  return new TableModels(readTableModel());
+}
+
+TimingModel *
+LibLoader::readModel(LibertyCell *cell)
+{
+  ModelKind kind = static_cast<ModelKind>(r_.u8());
+  switch (kind) {
+  case ModelKind::gate: {
+    TableModels *delay = readTableModels();
+    TableModels *slew = readTableModels();
+    return new GateTableModel(cell, delay, slew);
+  }
+  case ModelKind::check: {
+    TableModels *check = readTableModels();
+    return new CheckTableModel(cell, check);
+  }
+  default:
+    return nullptr;
+  }
+}
+
+////////////////////////////////////////////////////////////////
+
+FuncExpr *
+LibLoader::readFuncExpr(LibertyCell *cell)
+{
+  uint8_t op_code = r_.u8();
+  if (op_code == 0xFF)
+    return nullptr;
+  FuncExpr::Op op = static_cast<FuncExpr::Op>(op_code);
+  switch (op) {
+  case FuncExpr::Op::port: {
+    LibertyPort *port = readPortRef(cell);
+    return port ? FuncExpr::makePort(port) : nullptr;
+  }
+  case FuncExpr::Op::not_: {
+    FuncExpr *left = readFuncExpr(cell);
+    FuncExpr *right = readFuncExpr(cell);
+    (void) right;
+    return left ? FuncExpr::makeNot(left) : nullptr;
+  }
+  case FuncExpr::Op::or_: {
+    FuncExpr *left = readFuncExpr(cell);
+    FuncExpr *right = readFuncExpr(cell);
+    return (left && right) ? FuncExpr::makeOr(left, right) : nullptr;
+  }
+  case FuncExpr::Op::and_: {
+    FuncExpr *left = readFuncExpr(cell);
+    FuncExpr *right = readFuncExpr(cell);
+    return (left && right) ? FuncExpr::makeAnd(left, right) : nullptr;
+  }
+  case FuncExpr::Op::xor_: {
+    FuncExpr *left = readFuncExpr(cell);
+    FuncExpr *right = readFuncExpr(cell);
+    return (left && right) ? FuncExpr::makeXor(left, right) : nullptr;
+  }
+  case FuncExpr::Op::one:
+    readFuncExpr(cell);
+    readFuncExpr(cell);
+    return FuncExpr::makeOne();
+  case FuncExpr::Op::zero:
+    readFuncExpr(cell);
+    readFuncExpr(cell);
+    return FuncExpr::makeZero();
+  }
+  return nullptr;
+}
+
+TimingArcAttrsPtr
+LibLoader::readAttrs(LibertyCell *cell)
+{
+  uint32_t id = r_.u32();
+  if (id != kNullId && id < attrs_.size())
+    return attrs_[id];
+
+  TimingArcAttrsPtr attrs = std::make_shared<TimingArcAttrs>();
+  attrs->setTimingType(static_cast<TimingType>(r_.u8()));
+  attrs->setTimingSense(static_cast<TimingSense>(r_.u8()));
+  FuncExpr *cond = readFuncExpr(cell);
+  if (cond)
+    attrs->setCond(cond);
+  attrs->setSdfCondStart(r_.str());
+  attrs->setSdfCondEnd(r_.str());
+  attrs->setModeName(r_.str());
+  attrs->setModeValue(r_.str());
+  for (const RiseFall *rf : RiseFall::range()) {
+    TimingModel *model = readModel(cell);
+    if (model)
+      attrs->setModel(rf, model);
+  }
+  if (id != kNullId)
+    attrs_.push_back(attrs);
+  return attrs;
+}
+
+void
+LibLoader::readArcSet(LibertyCell *cell)
+{
+  LibertyPort *from = readPortRef(cell);
+  LibertyPort *to = readPortRef(cell);
+  LibertyPort *related_out = readPortRef(cell);
+  const TimingRole *role = TimingRole::find(r_.str().c_str());
+  TimingArcAttrsPtr attrs = readAttrs(cell);
+
+  // The resolved arc set is replayed directly rather than routed back through
+  // LibertyBuilder's inference, so roles and arcs come back exactly as the
+  // parser left them.
+  TimingArcSet *set = cell->makeTimingArcSet(from, to, related_out, role, attrs);
+
+  uint32_t arc_count = r_.u32();
+  for (uint32_t i = 0; i < arc_count; i++) {
+    const Transition *from_rf = Transition::find(r_.str());
+    const Transition *to_rf = Transition::find(r_.str());
+    uint8_t slot = r_.u8();
+    TimingModel *model = nullptr;
+    if (slot == 0)
+      model = attrs->model(RiseFall::rise());
+    else if (slot == 1)
+      model = attrs->model(RiseFall::fall());
+    // The TimingArc constructor registers itself with the set.
+    new TimingArc(set, from_rf, to_rf, model);
+  }
+}
+
+////////////////////////////////////////////////////////////////
+
+void
+LibLoader::readPort(LibertyCell *cell)
+{
+  const std::string name = r_.str();
+  PortKind kind = static_cast<PortKind>(r_.u8());
+  if (kind == PortKind::bus) {
+    int from = r_.i32();
+    int to = r_.i32();
+    BusDcl *dcl = nullptr;
+    if (r_.boolean()) {
+      const std::string dcl_name = r_.str();
+      int dcl_from = r_.i32();
+      int dcl_to = r_.i32();
+      dcl = cell->findBusDcl(dcl_name);
+      if (dcl == nullptr)
+        dcl = cell->makeBusDcl(dcl_name, dcl_from, dcl_to);
+    }
+    builder_.makeBusPort(cell, name, from, to, dcl);
+  }
+  else if (kind == PortKind::bundle) {
+    uint32_t count = r_.u32();
+    ConcretePortSeq *members = new ConcretePortSeq;
+    for (uint32_t i = 0; i < count; i++) {
+      LibertyPort *member = cell->findLibertyPort(r_.str());
+      if (member)
+        members->push_back(member);
+    }
+    builder_.makeBundlePort(cell, name, members);
+  }
+  else
+    builder_.makePort(cell, name);
+}
+
+void
+LibLoader::readPortAttrs(LibertyCell *cell)
+{
+  LibertyPort *port = cell->findLibertyPort(r_.str());
+
+  PortDirection *dir = directionFromCode(r_.u8());
+  if (port)
+    port->setDirection(dir);
+
+  for (const RiseFall *rf : RiseFall::range()) {
+    for (const MinMax *mm : MinMax::range()) {
+      bool exists = r_.boolean();
+      float value = r_.f32();
+      if (port && exists)
+        port->setCapacitance(rf, mm, value);
+    }
+  }
+  for (const MinMax *mm : MinMax::range()) {
+    bool exists = r_.boolean();
+    float value = r_.f32();
+    if (port && exists)
+      port->setSlewLimit(value, mm);
+  }
+  for (const MinMax *mm : MinMax::range()) {
+    bool exists = r_.boolean();
+    float value = r_.f32();
+    if (port && exists)
+      port->setCapacitanceLimit(value, mm);
+  }
+  for (const MinMax *mm : MinMax::range()) {
+    bool exists = r_.boolean();
+    float value = r_.f32();
+    if (port && exists)
+      port->setFanoutLimit(value, mm);
+  }
+
+  bool exists = r_.boolean();
+  float value = r_.f32();
+  if (port && exists)
+    port->setFanoutLoad(value);
+
+  exists = r_.boolean();
+  value = r_.f32();
+  if (port && exists)
+    port->setMinPeriod(value);
+
+  for (const RiseFall *rf : RiseFall::range()) {
+    exists = r_.boolean();
+    value = r_.f32();
+    if (port && exists)
+      port->setMinPulseWidth(rf, value);
+  }
+
+  bool is_clock = r_.boolean();
+  bool cg_clk = r_.boolean();
+  bool cg_enable = r_.boolean();
+  bool cg_out = r_.boolean();
+  bool pll_feedback = r_.boolean();
+  bool iso_data = r_.boolean();
+  bool iso_enable = r_.boolean();
+  bool ls_data = r_.boolean();
+  bool is_switch = r_.boolean();
+  bool is_pad = r_.boolean();
+  // isClockGate() also requires these cell-level flags, which the liberty
+  // reader derives from the port attributes rather than storing directly.
+  if (cg_clk)
+    cell->setHasClkGateClkPin();
+  if (cg_enable)
+    cell->setHasClkGateEnablePin();
+  if (port) {
+    port->setIsClock(is_clock);
+    port->setIsClockGateClock(cg_clk);
+    port->setIsClockGateEnable(cg_enable);
+    port->setIsClockGateOut(cg_out);
+    port->setIsPllFeedback(pll_feedback);
+    port->setIsolationCellData(iso_data);
+    port->setIsolationCellEnable(iso_enable);
+    port->setLevelShifterData(ls_data);
+    port->setIsSwitch(is_switch);
+    port->setIsPad(is_pad);
+  }
+
+  PwrGndType pg = static_cast<PwrGndType>(r_.u8());
+  const std::string voltage_name = r_.str();
+  ScanSignalType scan = static_cast<ScanSignalType>(r_.u8());
+  if (port) {
+    port->setPwrGndType(pg);
+    port->setVoltageName(voltage_name);
+    port->setScanSignalType(scan);
+  }
+
+  if (r_.boolean()) {
+    const RiseFall *trigger = RiseFall::find(static_cast<size_t>(r_.u8()));
+    const RiseFall *sense = RiseFall::find(static_cast<size_t>(r_.u8()));
+    if (port)
+      port->setPulseClk(trigger, sense);
+  }
+
+  FuncExpr *func = readFuncExpr(cell);
+  FuncExpr *tristate = readFuncExpr(cell);
+  LibertyPort *related_power = readPortRef(cell);
+  LibertyPort *related_ground = readPortRef(cell);
+  if (port) {
+    if (func)
+      port->setFunction(func);
+    if (tristate)
+      port->setTristateEnable(tristate);
+    if (related_power)
+      port->setRelatedPowerPort(related_power);
+    if (related_ground)
+      port->setRelatedGroundPort(related_ground);
+  }
+}
+
+////////////////////////////////////////////////////////////////
+
+void
+LibLoader::readCell()
+{
+  const std::string name = r_.str();
+  const std::string filename = r_.str();
+  LibertyCell *cell = builder_.makeCell(lib_, name, filename);
+
+  cell->setArea(r_.f32());
+  cell->setDontUse(r_.boolean());
+  cell->setIsMacro(r_.boolean());
+  cell->setIsMemory(r_.boolean());
+  cell->setIsPad(r_.boolean());
+  cell->setIsClockCell(r_.boolean());
+  cell->setIsLevelShifter(r_.boolean());
+  cell->setLevelShifterType(static_cast<LevelShifterType>(r_.u8()));
+  cell->setIsIsolationCell(r_.boolean());
+  cell->setAlwaysOn(r_.boolean());
+  cell->setSwitchCellType(static_cast<SwitchCellType>(r_.u8()));
+  cell->setInterfaceTiming(r_.boolean());
+  cell->setFootprint(r_.str());
+  cell->setUserFunctionClass(r_.str());
+  cell->setOcvArcDepth(r_.f32());
+  cell->setHasInferedRegTimingArcs(r_.boolean());
+  cell->setClockGateType(static_cast<ClockGateType>(r_.u8()));
+
+  if (r_.boolean())
+    cell->setScaleFactors(lib_->findScaleFactors(r_.str()));
+
+  uint32_t port_count = r_.u32();
+  for (uint32_t i = 0; i < port_count; i++)
+    readPort(cell);
+
+  uint32_t attr_count = r_.u32();
+  for (uint32_t i = 0; i < attr_count; i++)
+    readPortAttrs(cell);
+
+  uint32_t seq_count = r_.u32();
+  for (uint32_t i = 0; i < seq_count; i++) {
+    bool is_register = r_.boolean();
+    FuncExpr *clk = readFuncExpr(cell);
+    FuncExpr *data = readFuncExpr(cell);
+    FuncExpr *clear = readFuncExpr(cell);
+    FuncExpr *preset = readFuncExpr(cell);
+    LogicValue clr_preset_out = static_cast<LogicValue>(r_.u8());
+    LogicValue clr_preset_out_inv = static_cast<LogicValue>(r_.u8());
+    LibertyPort *output = readPortRef(cell);
+    LibertyPort *output_inv = readPortRef(cell);
+    // Sequentials are stored already split per bit, so each is replayed as a
+    // size-1 group; makeSequential takes ownership of the expressions.
+    cell->makeSequential(1, is_register, clk, data, clear, preset,
+                         clr_preset_out, clr_preset_out_inv, output, output_inv);
+  }
+
+  if (r_.boolean()) {
+    LibertyPortSeq inputs;
+    uint32_t input_count = r_.u32();
+    for (uint32_t i = 0; i < input_count; i++) {
+      LibertyPort *port = readPortRef(cell);
+      if (port)
+        inputs.push_back(port);
+    }
+    LibertyPortSeq internals;
+    uint32_t internal_count = r_.u32();
+    for (uint32_t i = 0; i < internal_count; i++) {
+      LibertyPort *port = readPortRef(cell);
+      if (port)
+        internals.push_back(port);
+    }
+
+    StatetableRows rows;
+    uint32_t row_count = r_.u32();
+    for (uint32_t i = 0; i < row_count; i++) {
+      StateInputValues input_values;
+      uint32_t n = r_.u32();
+      for (uint32_t j = 0; j < n; j++)
+        input_values.push_back(static_cast<StateInputValue>(r_.u8()));
+      StateInternalValues current_values;
+      n = r_.u32();
+      for (uint32_t j = 0; j < n; j++)
+        current_values.push_back(static_cast<StateInternalValue>(r_.u8()));
+      StateInternalValues next_values;
+      n = r_.u32();
+      for (uint32_t j = 0; j < n; j++)
+        next_values.push_back(static_cast<StateInternalValue>(r_.u8()));
+      rows.emplace_back(input_values, current_values, next_values);
+    }
+    cell->makeStatetable(inputs, internals, rows);
+  }
+
+  uint32_t gen_clk_count = r_.u32();
+  for (uint32_t i = 0; i < gen_clk_count; i++) {
+    const std::string gc_name = r_.str();
+    const std::string clock_pin = r_.str();
+    const std::string master_pin = r_.str();
+    int divided_by = r_.i32();
+    int multiplied_by = r_.i32();
+    float duty_cycle = r_.f32();
+    bool invert = r_.boolean();
+    uint32_t edge_count = r_.u32();
+    IntSeq *edges = edge_count ? new IntSeq : nullptr;
+    for (uint32_t e = 0; e < edge_count; e++)
+      edges->push_back(r_.i32());
+    FloatSeq shift_values = r_.floats();
+    FloatSeq *shifts = shift_values.empty() ? nullptr : new FloatSeq(shift_values);
+    // makeGeneratedClock copies edges/shifts, so ownership stays here.
+    cell->makeGeneratedClock(gc_name.c_str(), clock_pin.c_str(), master_pin.c_str(),
+                             divided_by, multiplied_by, duty_cycle, invert,
+                             edges, shifts);
+    delete edges;
+    delete shifts;
+  }
+
+  uint32_t arc_set_count = r_.u32();
+  for (uint32_t i = 0; i < arc_set_count; i++)
+    readArcSet(cell);
+
+  cell->finish(infer_latches_, report_, debug_);
+}
+
+void
+LibLoader::readUnit(Unit *unit)
+{
+  unit->setScale(r_.f32());
+  unit->setSuffix(r_.str().c_str());
+  unit->setDigits(r_.i32());
+}
+
+LibertyLibrary *
+LibLoader::read()
+{
+  const std::string name = r_.str();
+  const std::string filename = r_.str();
+  lib_ = network_->makeLibertyLibrary(name, filename);
+  if (lib_ == nullptr)
+    report_->error(1358, "cannot make liberty library for {}.", filename_);
+
+  lib_->setDelayModelType(static_cast<DelayModelType>(r_.u8()));
+  char brkt_left = static_cast<char>(r_.u8());
+  char brkt_right = static_cast<char>(r_.u8());
+  lib_->setBusBrkts(brkt_left, brkt_right);
+
+  Units *units = lib_->units();
+  readUnit(units->timeUnit());
+  readUnit(units->capacitanceUnit());
+  readUnit(units->voltageUnit());
+  readUnit(units->resistanceUnit());
+  readUnit(units->currentUnit());
+  readUnit(units->powerUnit());
+  readUnit(units->distanceUnit());
+  readUnit(units->scalarUnit());
+
+  lib_->setNominalProcess(r_.f32());
+  lib_->setNominalVoltage(r_.f32());
+  lib_->setNominalTemperature(r_.f32());
+  lib_->setDefaultInputPinCap(r_.f32());
+  lib_->setDefaultOutputPinCap(r_.f32());
+  lib_->setDefaultBidirectPinCap(r_.f32());
+
+  for (const RiseFall *rf : RiseFall::range()) {
+    bool exists = r_.boolean();
+    float value = r_.f32();
+    if (exists)
+      lib_->setDefaultIntrinsic(rf, value);
+  }
+  for (const RiseFall *rf : RiseFall::range()) {
+    bool exists = r_.boolean();
+    float value = r_.f32();
+    if (exists)
+      lib_->setDefaultBidirectPinRes(rf, value);
+  }
+  for (const RiseFall *rf : RiseFall::range()) {
+    bool exists = r_.boolean();
+    float value = r_.f32();
+    if (exists)
+      lib_->setDefaultOutputPinRes(rf, value);
+  }
+
+  bool exists = r_.boolean();
+  float value = r_.f32();
+  if (exists)
+    lib_->setDefaultFanoutLoad(value);
+  exists = r_.boolean();
+  value = r_.f32();
+  if (exists)
+    lib_->setDefaultMaxCapacitance(value);
+  exists = r_.boolean();
+  value = r_.f32();
+  if (exists)
+    lib_->setDefaultMaxFanout(value);
+  exists = r_.boolean();
+  value = r_.f32();
+  if (exists)
+    lib_->setDefaultMaxSlew(value);
+
+  for (const RiseFall *rf : RiseFall::range()) lib_->setInputThreshold(rf, r_.f32());
+  for (const RiseFall *rf : RiseFall::range()) lib_->setOutputThreshold(rf, r_.f32());
+  for (const RiseFall *rf : RiseFall::range()) lib_->setSlewLowerThreshold(rf, r_.f32());
+  for (const RiseFall *rf : RiseFall::range()) lib_->setSlewUpperThreshold(rf, r_.f32());
+  lib_->setSlewDerateFromLibrary(r_.f32());
+  lib_->setOcvArcDepth(r_.f32());
+
+  uint32_t bus_dcl_count = r_.u32();
+  for (uint32_t i = 0; i < bus_dcl_count; i++) {
+    const std::string dcl_name = r_.str();
+    int from = r_.i32();
+    int to = r_.i32();
+    lib_->makeBusDcl(dcl_name, from, to);
+  }
+
+  uint32_t template_count = r_.u32();
+  for (uint32_t i = 0; i < template_count; i++) {
+    const std::string tmpl_name = r_.str();
+    TableTemplateType type = static_cast<TableTemplateType>(r_.u8());
+    TableTemplate *tmpl = lib_->findTableTemplate(tmpl_name, type);
+    if (tmpl == nullptr)
+      tmpl = lib_->makeTableTemplate(tmpl_name, type);
+    TableAxisPtr axis1 = readAxisRef();
+    TableAxisPtr axis2 = readAxisRef();
+    TableAxisPtr axis3 = readAxisRef();
+    if (tmpl) {
+      tmpl->setAxis1(axis1);
+      tmpl->setAxis2(axis2);
+      tmpl->setAxis3(axis3);
+    }
+  }
+
+  if (r_.boolean()) {
+    OperatingConditions *op_cond = lib_->makeOperatingConditions(r_.str());
+    op_cond->setProcess(r_.f32());
+    op_cond->setVoltage(r_.f32());
+    op_cond->setTemperature(r_.f32());
+    op_cond->setWireloadTree(static_cast<WireloadTree>(r_.u8()));
+    lib_->setDefaultOperatingConditions(op_cond);
+  }
+
+  if (r_.boolean()) {
+    ScaleFactors *scales = lib_->makeScaleFactors(r_.str());
+    for (int type = 0; type < scale_factor_type_count; type++) {
+      for (int pvt = 0; pvt < scale_factor_pvt_count; pvt++) {
+        for (const RiseFall *rf : RiseFall::range())
+          scales->setScale(static_cast<ScaleFactorType>(type),
+                           static_cast<ScaleFactorPvt>(pvt), rf, r_.f32());
+      }
+    }
+    lib_->setScaleFactors(scales);
+  }
+
+  uint32_t cell_count = r_.u32();
+  for (uint32_t i = 0; i < cell_count; i++)
+    readCell();
+
+  if (r_.failed())
+    report_->error(1359, "{} is truncated or corrupt.", filename_);
+  return lib_;
+}
+
+} // namespace
+
+LibertyLibrary *
+readLibDbFile(std::string_view filename,
+              Network *network)
+{
+  Report *report = network->report();
+  std::string path(filename);
+
+  FILE *f = fopen(path.c_str(), "rb");
+  if (f == nullptr)
+    report->error(1360, "cannot open {}.", path);
+
+  LibDbHeader hdr{};
+  bool hdr_ok = fread(&hdr, sizeof hdr, 1, f) == 1
+    && std::memcmp(hdr.magic, kLibDbMagic, sizeof hdr.magic) == 0;
+  if (!hdr_ok) {
+    fclose(f);
+    report->error(1361, "{} is not a liberty database.", path);
+  }
+  if (hdr.version != kLibDbVersion) {
+    fclose(f);
+    report->error(1362, "{} is liberty database version {}, expected {}.",
+                  path, hdr.version, kLibDbVersion);
+  }
+  if (hdr.pointer_size != sizeof(void *)) {
+    fclose(f);
+    report->error(1363, "{} was written on a different architecture.", path);
+  }
+
+  uint32_t string_count = 0;
+  bool ok = fread(&string_count, sizeof string_count, 1, f) == 1;
+  std::vector<uint8_t> string_bytes(hdr.string_bytes);
+  if (ok && hdr.string_bytes)
+    ok = fread(string_bytes.data(), hdr.string_bytes, 1, f) == 1;
+  std::vector<uint8_t> body(hdr.body_bytes);
+  if (ok && hdr.body_bytes)
+    ok = fread(body.data(), hdr.body_bytes, 1, f) == 1;
+  fclose(f);
+  if (!ok)
+    report->error(1355, "{} is truncated.", path);
+
+  std::vector<std::string> strings;
+  strings.reserve(string_count);
+  size_t pos = 0;
+  for (uint32_t i = 0; i < string_count; i++) {
+    if (pos + sizeof(uint32_t) > string_bytes.size())
+      report->error(1356, "{} has a corrupt string table.", path);
+    uint32_t len;
+    std::memcpy(&len, string_bytes.data() + pos, sizeof len);
+    pos += sizeof len;
+    if (pos + len > string_bytes.size())
+      report->error(1356, "{} has a corrupt string table.", path);
+    strings.emplace_back(reinterpret_cast<const char *>(string_bytes.data() + pos), len);
+    pos += len;
+  }
+
+  DbReader reader(body.data(), body.size(), &strings);
+  LibLoader loader(reader, filename, network, hdr.infer_latches != 0);
+  return loader.read();
+}
+
+} // namespace sta

--- a/liberty/LibDbReader.cc
+++ b/liberty/LibDbReader.cc
@@ -22,6 +22,13 @@
 // 
 // This notice may not be removed or altered from any source distribution.
 
+// read_lib_db: rebuild one NLDM LibertyLibrary from a .libdb cache.
+//
+// File layout: [header][string_count][string table][body]
+// Body field order must match LibWriter in LibDbWriter.cc.
+// Shared axes/tables/attrs: first use reads id + full data; later uses reuse by id.
+// Strings: body stores an index; the string table holds the text once.
+
 #include "LibDb.hh"
 
 #include <cstdio>
@@ -47,16 +54,10 @@
 
 namespace sta {
 
-namespace {
-
-constexpr uint32_t kNullId = 0xFFFFFFFFu;
-
-enum class ModelKind : uint8_t { none = 0, gate = 1, check = 2 };
-enum class PortKind : uint8_t { scalar = 0, bus = 1, bundle = 2 };
-
-PortDirection *
+static PortDirection *
 directionFromCode(uint8_t code)
 {
+  // Inverse of directionCode() in the writer.
   switch (code) {
   case 0: return PortDirection::input();
   case 1: return PortDirection::output();
@@ -70,20 +71,19 @@ directionFromCode(uint8_t code)
   }
 }
 
+// Inverse of LibWriter: read body fields in the same order and build objects.
 class LibLoader
 {
 public:
   LibLoader(DbReader &r,
             std::string_view filename,
-            Network *network,
-            bool infer_latches) :
+            Network *network) :
     r_(r),
     filename_(filename),
     network_(network),
     report_(network->report()),
     debug_(network->debug()),
-    builder_(network->debug(), network->report()),
-    infer_latches_(infer_latches)
+    builder_(network->debug(), network->report())
   {
   }
 
@@ -104,27 +104,28 @@ private:
   TableAxisPtr readAxisRef();
   LibertyPort *readPortRef(LibertyCell *cell);
 
-  DbReader &r_;
+  DbReader &r_;                 // bookmark over body bytes + string list
   std::string filename_;
   Network *network_;
   Report *report_;
   Debug *debug_;
-  LibertyBuilder builder_;
-  bool infer_latches_;
+  LibertyBuilder builder_;      // creates cells/ports like the liberty parser
   LibertyLibrary *lib_{nullptr};
 
+  // Shared objects seen so far (index = number written in the file).
   std::vector<TableAxisPtr> axes_;
   std::vector<TablePtr> tables_;
   std::vector<TimingArcAttrsPtr> attrs_;
 };
 
 ////////////////////////////////////////////////////////////////
-// Interned references. An id at or past the end of the table means the
-// definition follows inline, mirroring the writer.
+// Shared objects: first time we see a number, the full data follows and we
+// remember it. Next time that number appears, reuse the remembered object.
 
 LibertyPort *
 LibLoader::readPortRef(LibertyCell *cell)
 {
+  // Optional port by name (flag + string), not a raw pointer.
   if (!r_.boolean())
     return nullptr;
   const std::string &name = r_.str();
@@ -135,11 +136,12 @@ TableAxisPtr
 LibLoader::readAxisRef()
 {
   uint32_t id = r_.u32();
-  if (id == kNullId)
+  if (id == lib_db_id_null)
     return nullptr;
   if (id < axes_.size())
-    return axes_[id];
+    return axes_[id];  // seen before
 
+  // First time: full axis data is next; save it under this number.
   TableAxisVariable var = static_cast<TableAxisVariable>(r_.u8());
   FloatSeq values = r_.floats();
   TableAxisPtr axis = std::make_shared<TableAxis>(var, std::move(values));
@@ -151,11 +153,13 @@ TablePtr
 LibLoader::readTableRef()
 {
   uint32_t id = r_.u32();
-  if (id == kNullId)
+  if (id == lib_db_id_null)
     return nullptr;
   if (id < tables_.size())
-    return tables_[id];
+    return tables_[id];  // seen before
 
+  // First time: full table data is next.
+  // order 0/1/2/3 picks scalar / 1D / 2D / 3D Table ctor.
   int order = r_.u8();
   TableAxisPtr axis1 = readAxisRef();
   TableAxisPtr axis2 = readAxisRef();
@@ -211,14 +215,15 @@ LibLoader::readTableModels()
 TimingModel *
 LibLoader::readModel(LibertyCell *cell)
 {
-  ModelKind kind = static_cast<ModelKind>(r_.u8());
+  // One byte kind, then delay/slew (gate) or check tables.
+  LibDbModelKind kind = static_cast<LibDbModelKind>(r_.u8());
   switch (kind) {
-  case ModelKind::gate: {
+  case LibDbModelKind::gate: {
     TableModels *delay = readTableModels();
     TableModels *slew = readTableModels();
     return new GateTableModel(cell, delay, slew);
   }
-  case ModelKind::check: {
+  case LibDbModelKind::check: {
     TableModels *check = readTableModels();
     return new CheckTableModel(cell, check);
   }
@@ -228,6 +233,7 @@ LibLoader::readModel(LibertyCell *cell)
 }
 
 ////////////////////////////////////////////////////////////////
+// Mirror writeFuncExpr. not_ still reads a dummy right child to stay aligned.
 
 FuncExpr *
 LibLoader::readFuncExpr(LibertyCell *cell)
@@ -243,6 +249,7 @@ LibLoader::readFuncExpr(LibertyCell *cell)
   }
   case FuncExpr::Op::not_: {
     FuncExpr *left = readFuncExpr(cell);
+    // Writer always emits left+right; discard the unused right for unary not.
     FuncExpr *right = readFuncExpr(cell);
     (void) right;
     return left ? FuncExpr::makeNot(left) : nullptr;
@@ -277,8 +284,9 @@ LibLoader::readFuncExpr(LibertyCell *cell)
 TimingArcAttrsPtr
 LibLoader::readAttrs(LibertyCell *cell)
 {
+  // Reuse by id, or build TimingArcAttrs and store if id was new.
   uint32_t id = r_.u32();
-  if (id != kNullId && id < attrs_.size())
+  if (id != lib_db_id_null && id < attrs_.size())
     return attrs_[id];
 
   TimingArcAttrsPtr attrs = std::make_shared<TimingArcAttrs>();
@@ -296,7 +304,7 @@ LibLoader::readAttrs(LibertyCell *cell)
     if (model)
       attrs->setModel(rf, model);
   }
-  if (id != kNullId)
+  if (id != lib_db_id_null)
     attrs_.push_back(attrs);
   return attrs;
 }
@@ -310,11 +318,10 @@ LibLoader::readArcSet(LibertyCell *cell)
   const TimingRole *role = TimingRole::find(r_.str().c_str());
   TimingArcAttrsPtr attrs = readAttrs(cell);
 
-  // The resolved arc set is replayed directly rather than routed back through
-  // LibertyBuilder's inference, so roles and arcs come back exactly as the
-  // parser left them.
+  // Replay resolved arcs (do not re-infer via LibertyBuilder).
   TimingArcSet *set = cell->makeTimingArcSet(from, to, related_out, role, attrs);
 
+  // slot 0/1 = rise/fall model from attrs; 0xFF = no model.
   uint32_t arc_count = r_.u32();
   for (uint32_t i = 0; i < arc_count; i++) {
     const Transition *from_rf = Transition::find(r_.str());
@@ -325,7 +332,6 @@ LibLoader::readArcSet(LibertyCell *cell)
       model = attrs->model(RiseFall::rise());
     else if (slot == 1)
       model = attrs->model(RiseFall::fall());
-    // The TimingArc constructor registers itself with the set.
     new TimingArc(set, from_rf, to_rf, model);
   }
 }
@@ -335,9 +341,10 @@ LibLoader::readArcSet(LibertyCell *cell)
 void
 LibLoader::readPort(LibertyCell *cell)
 {
+  // Create port shell (scalar/bus/bundle); attrs come in a later pass.
   const std::string name = r_.str();
-  PortKind kind = static_cast<PortKind>(r_.u8());
-  if (kind == PortKind::bus) {
+  LibDbPortKind kind = static_cast<LibDbPortKind>(r_.u8());
+  if (kind == LibDbPortKind::bus) {
     int from = r_.i32();
     int to = r_.i32();
     BusDcl *dcl = nullptr;
@@ -351,7 +358,7 @@ LibLoader::readPort(LibertyCell *cell)
     }
     builder_.makeBusPort(cell, name, from, to, dcl);
   }
-  else if (kind == PortKind::bundle) {
+  else if (kind == LibDbPortKind::bundle) {
     uint32_t count = r_.u32();
     ConcretePortSeq *members = new ConcretePortSeq;
     for (uint32_t i = 0; i < count; i++) {
@@ -368,6 +375,7 @@ LibLoader::readPort(LibertyCell *cell)
 void
 LibLoader::readPortAttrs(LibertyCell *cell)
 {
+  // Same order as writePortAttrs; skip set* when exists flag is false.
   LibertyPort *port = cell->findLibertyPort(r_.str());
 
   PortDirection *dir = directionFromCode(r_.u8());
@@ -428,8 +436,7 @@ LibLoader::readPortAttrs(LibertyCell *cell)
   bool ls_data = r_.boolean();
   bool is_switch = r_.boolean();
   bool is_pad = r_.boolean();
-  // isClockGate() also requires these cell-level flags, which the liberty
-  // reader derives from the port attributes rather than storing directly.
+  // Cell-level bits required by isClockGate() (same as liberty reader).
   if (cg_clk)
     cell->setHasClkGateClkPin();
   if (cg_enable)
@@ -484,6 +491,7 @@ LibLoader::readPortAttrs(LibertyCell *cell)
 void
 LibLoader::readCell()
 {
+  // Ports → port attrs → sequentials → statetable → gen clocks → arcs → finish(false).
   const std::string name = r_.str();
   const std::string filename = r_.str();
   LibertyCell *cell = builder_.makeCell(lib_, name, filename);
@@ -528,8 +536,7 @@ LibLoader::readCell()
     LogicValue clr_preset_out_inv = static_cast<LogicValue>(r_.u8());
     LibertyPort *output = readPortRef(cell);
     LibertyPort *output_inv = readPortRef(cell);
-    // Sequentials are stored already split per bit, so each is replayed as a
-    // size-1 group; makeSequential takes ownership of the expressions.
+    // Already split per bit; size-1 group. makeSequential owns the exprs.
     cell->makeSequential(1, is_register, clk, data, clear, preset,
                          clr_preset_out, clr_preset_out_inv, output, output_inv);
   }
@@ -585,7 +592,7 @@ LibLoader::readCell()
       edges->push_back(r_.i32());
     FloatSeq shift_values = r_.floats();
     FloatSeq *shifts = shift_values.empty() ? nullptr : new FloatSeq(shift_values);
-    // makeGeneratedClock copies edges/shifts, so ownership stays here.
+    // makeGeneratedClock copies edges/shifts.
     cell->makeGeneratedClock(gc_name.c_str(), clock_pin.c_str(), master_pin.c_str(),
                              divided_by, multiplied_by, duty_cycle, invert,
                              edges, shifts);
@@ -597,7 +604,8 @@ LibLoader::readCell()
   for (uint32_t i = 0; i < arc_set_count; i++)
     readArcSet(cell);
 
-  cell->finish(infer_latches_, report_, debug_);
+  // false = do not re-derive latch enables; arcs/roles already match the original liberty.
+  cell->finish(false, report_, debug_);
 }
 
 void
@@ -611,6 +619,8 @@ LibLoader::readUnit(Unit *unit)
 LibertyLibrary *
 LibLoader::read()
 {
+  // Same field order as LibWriter::writeLibrary — create empty library, then
+  // fill units/defaults/templates, then each cell via readCell().
   const std::string name = r_.str();
   const std::string filename = r_.str();
   lib_ = network_->makeLibertyLibrary(name, filename);
@@ -690,6 +700,7 @@ LibLoader::read()
     lib_->makeBusDcl(dcl_name, from, to);
   }
 
+  // Templates/axes must exist before cells that point at them.
   uint32_t template_count = r_.u32();
   for (uint32_t i = 0; i < template_count; i++) {
     const std::string tmpl_name = r_.str();
@@ -732,39 +743,37 @@ LibLoader::read()
   for (uint32_t i = 0; i < cell_count; i++)
     readCell();
 
+  // DbReader sets this if we tried to read past the end of the body.
   if (r_.failed())
     report_->error(1359, "{} is truncated or corrupt.", filename_);
   return lib_;
 }
 
-} // namespace
-
 LibertyLibrary *
 readLibDbFile(std::string_view filename,
               Network *network)
 {
+  // Validate .libdb + version, load string table, then LibLoader::read().
   Report *report = network->report();
   std::string path(filename);
 
+  if (!filename.ends_with(".libdb"))
+    report->error(1361, "{} must end with .libdb.", path);
+
   FILE *f = fopen(path.c_str(), "rb");
   if (f == nullptr)
-    report->error(1360, "cannot open {}.", path);
+    report->error(1366, "cannot open {}.", path);
 
+  // File layout: [header][string_count][string bytes][body bytes]
   LibDbHeader hdr{};
-  bool hdr_ok = fread(&hdr, sizeof hdr, 1, f) == 1
-    && std::memcmp(hdr.magic, kLibDbMagic, sizeof hdr.magic) == 0;
-  if (!hdr_ok) {
+  if (fread(&hdr, sizeof hdr, 1, f) != 1) {
     fclose(f);
-    report->error(1361, "{} is not a liberty database.", path);
+    report->error(1355, "{} is truncated.", path);
   }
-  if (hdr.version != kLibDbVersion) {
+  if (hdr.version != lib_db_version) {
     fclose(f);
     report->error(1362, "{} is liberty database version {}, expected {}.",
-                  path, hdr.version, kLibDbVersion);
-  }
-  if (hdr.pointer_size != sizeof(void *)) {
-    fclose(f);
-    report->error(1363, "{} was written on a different architecture.", path);
+                  path, hdr.version, lib_db_version);
   }
 
   uint32_t string_count = 0;
@@ -777,25 +786,28 @@ readLibDbFile(std::string_view filename,
     ok = fread(body.data(), hdr.body_bytes, 1, f) == 1;
   fclose(f);
   if (!ok)
-    report->error(1355, "{} is truncated.", path);
+    report->error(1363, "{} is truncated.", path);
 
+  // Unpack (length, characters)* into the string list DbReader::str() uses.
   std::vector<std::string> strings;
   strings.reserve(string_count);
   size_t pos = 0;
   for (uint32_t i = 0; i < string_count; i++) {
-    if (pos + sizeof(uint32_t) > string_bytes.size())
-      report->error(1356, "{} has a corrupt string table.", path);
-    uint32_t len;
-    std::memcpy(&len, string_bytes.data() + pos, sizeof len);
-    pos += sizeof len;
-    if (pos + len > string_bytes.size())
+    uint32_t len = 0;
+    bool len_ok = pos + sizeof len <= string_bytes.size();
+    if (len_ok) {
+      std::memcpy(&len, string_bytes.data() + pos, sizeof len);
+      pos += sizeof len;
+    }
+    if (!len_ok || pos + len > string_bytes.size())
       report->error(1356, "{} has a corrupt string table.", path);
     strings.emplace_back(reinterpret_cast<const char *>(string_bytes.data() + pos), len);
     pos += len;
   }
 
+  // Hand body + string list to the loader; it rebuilds the library object.
   DbReader reader(body.data(), body.size(), &strings);
-  LibLoader loader(reader, filename, network, hdr.infer_latches != 0);
+  LibLoader loader(reader, filename, network);
   return loader.read();
 }
 

--- a/liberty/LibDbWriter.cc
+++ b/liberty/LibDbWriter.cc
@@ -1,0 +1,755 @@
+// OpenSTA, Static Timing Analyzer
+// Copyright (c) 2026, Parallax Software, Inc.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+// 
+// The origin of this software must not be misrepresented; you must not
+// claim that you wrote the original software.
+// 
+// Altered source versions must be plainly marked as such, and must not be
+// misrepresented as being the original software.
+// 
+// This notice may not be removed or altered from any source distribution.
+
+#include "LibDb.hh"
+
+#include <cstdio>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "ConcreteLibrary.hh"
+#include "FuncExpr.hh"
+#include "GeneratedClock.hh"
+#include "Liberty.hh"
+#include "PortDirection.hh"
+#include "Report.hh"
+#include "Sequential.hh"
+#include "TableModel.hh"
+#include "TimingArc.hh"
+#include "TimingModel.hh"
+#include "TimingRole.hh"
+#include "Transition.hh"
+#include "Units.hh"
+
+namespace sta {
+
+namespace {
+
+constexpr uint32_t kNullId = 0xFFFFFFFFu;
+
+enum class ModelKind : uint8_t { none = 0, gate = 1, check = 2 };
+enum class PortKind : uint8_t { scalar = 0, bus = 1, bundle = 2 };
+
+uint8_t
+directionCode(const PortDirection *dir)
+{
+  if (dir == PortDirection::input()) return 0;
+  if (dir == PortDirection::output()) return 1;
+  if (dir == PortDirection::tristate()) return 2;
+  if (dir == PortDirection::bidirect()) return 3;
+  if (dir == PortDirection::internal()) return 4;
+  if (dir == PortDirection::ground()) return 5;
+  if (dir == PortDirection::power()) return 6;
+  if (dir == PortDirection::well()) return 7;
+  return 8;
+}
+
+class LibWriter
+{
+public:
+  LibWriter(LibertyLibrary *lib,
+            Report *report) :
+    lib_(lib),
+    report_(report)
+  {
+  }
+
+  void write(const char *path);
+
+private:
+  void writeLibrary();
+  void writeUnit(const Unit *unit);
+  void writeCell(LibertyCell *cell);
+  void writePort(LibertyPort *port);
+  void writePortAttrs(LibertyPort *port);
+  void writeFuncExpr(const FuncExpr *expr);
+  void writeArcSet(TimingArcSet *set);
+  void writeAttrs(TimingArcSet *set);
+  void writeModel(const TimingModel *model);
+  void writeTableModels(const TableModels *models);
+  void writeTableModel(const TableModel *model);
+  void writeTableRef(const TablePtr &table);
+  void writeAxisRef(const TableAxisPtr &axis);
+  void writeRiseFallMinMax(const LibertyPort *port);
+  void writeMinMaxLimit(const LibertyPort *port,
+                        void (LibertyPort::*getter)(const MinMax *, float &, bool &) const);
+  void writePortRef(const LibertyPort *port);
+
+  DbWriter w_;
+  LibertyLibrary *lib_;
+  Report *report_;
+  std::map<const TableAxis *, uint32_t> axis_ids_;
+  std::map<const Table *, uint32_t> table_ids_;
+  // Arc sets that share a TimingArcAttrs share its models, and a model is
+  // owned by exactly one attrs, so the model pointer pair identifies the
+  // attrs group without needing access to the attrs pointer itself.
+  std::map<std::pair<const TimingModel *, const TimingModel *>, uint32_t> attrs_ids_;
+};
+
+////////////////////////////////////////////////////////////////
+// Interned references.
+//
+// An id equal to the next unused id means the definition follows inline. That
+// keeps the file single-pass in both directions with no section offsets.
+
+void
+LibWriter::writePortRef(const LibertyPort *port)
+{
+  // A presence flag rather than a sentinel id, because any 32-bit value is a
+  // legal string table index.
+  if (port == nullptr) {
+    w_.boolean(false);
+    return;
+  }
+  w_.boolean(true);
+  w_.str(port->name());
+}
+
+void
+LibWriter::writeAxisRef(const TableAxisPtr &axis)
+{
+  if (!axis) {
+    w_.u32(kNullId);
+    return;
+  }
+  auto it = axis_ids_.find(axis.get());
+  if (it != axis_ids_.end()) {
+    w_.u32(it->second);
+    return;
+  }
+  uint32_t id = static_cast<uint32_t>(axis_ids_.size());
+  axis_ids_[axis.get()] = id;
+  w_.u32(id);
+  w_.u8(static_cast<uint8_t>(axis->variable()));
+  w_.floats(axis->values());
+}
+
+void
+LibWriter::writeTableRef(const TablePtr &table)
+{
+  if (!table) {
+    w_.u32(kNullId);
+    return;
+  }
+  auto it = table_ids_.find(table.get());
+  if (it != table_ids_.end()) {
+    w_.u32(it->second);
+    return;
+  }
+  uint32_t id = static_cast<uint32_t>(table_ids_.size());
+  table_ids_[table.get()] = id;
+  w_.u32(id);
+
+  int order = table->order();
+  w_.u8(static_cast<uint8_t>(order));
+  writeAxisRef(table->axis1ptr());
+  writeAxisRef(table->axis2ptr());
+  writeAxisRef(table->axis3ptr());
+
+  if (order == 0)
+    w_.f32(table->value(size_t(0), size_t(0), size_t(0)));
+  else if (order == 1) {
+    const FloatSeq *values = table->values();
+    static const FloatSeq empty;
+    w_.floats(values ? *values : empty);
+  }
+  else {
+    // Orders 2 and 3 share one FloatTable; order 3 flattens (axis1, axis2)
+    // into the row index, so storing rows verbatim preserves both layouts.
+    const FloatTable *values = table->values3();
+    uint32_t rows = values ? static_cast<uint32_t>(values->size()) : 0;
+    w_.u32(rows);
+    for (uint32_t i = 0; i < rows; i++)
+      w_.floats((*values)[i]);
+  }
+}
+
+////////////////////////////////////////////////////////////////
+// Timing models.
+
+void
+LibWriter::writeTableModel(const TableModel *model)
+{
+  if (model == nullptr) {
+    w_.boolean(false);
+    return;
+  }
+  w_.boolean(true);
+  writeTableRef(model->table());
+  TableTemplate *tmpl = model->tblTemplate();
+  if (tmpl) {
+    w_.boolean(true);
+    w_.str(tmpl->name());
+    w_.u8(static_cast<uint8_t>(tmpl->type()));
+  }
+  else
+    w_.boolean(false);
+  w_.u8(static_cast<uint8_t>(model->scaleFactorType()));
+  w_.u8(static_cast<uint8_t>(model->rfIndex()));
+}
+
+void
+LibWriter::writeTableModels(const TableModels *models)
+{
+  if (models == nullptr) {
+    w_.boolean(false);
+    return;
+  }
+  w_.boolean(true);
+  // Only the NLDM model is stored. sigma/std_dev/mean_shift/skewness are LVF
+  // and are dropped with CCS; see kFlagHasLvf.
+  writeTableModel(models->model());
+}
+
+void
+LibWriter::writeModel(const TimingModel *model)
+{
+  if (const GateTableModel *gate = dynamic_cast<const GateTableModel *>(model)) {
+    w_.u8(static_cast<uint8_t>(ModelKind::gate));
+    writeTableModels(gate->delayModels());
+    writeTableModels(gate->slewModels());
+  }
+  else if (const CheckTableModel *check = dynamic_cast<const CheckTableModel *>(model)) {
+    w_.u8(static_cast<uint8_t>(ModelKind::check));
+    writeTableModels(check->checkModels());
+  }
+  else
+    w_.u8(static_cast<uint8_t>(ModelKind::none));
+}
+
+////////////////////////////////////////////////////////////////
+
+void
+LibWriter::writeFuncExpr(const FuncExpr *expr)
+{
+  if (expr == nullptr) {
+    w_.u8(0xFF);
+    return;
+  }
+  w_.u8(static_cast<uint8_t>(expr->op()));
+  if (expr->op() == FuncExpr::Op::port) {
+    writePortRef(expr->port());
+    return;
+  }
+  writeFuncExpr(expr->left());
+  writeFuncExpr(expr->right());
+}
+
+void
+LibWriter::writeAttrs(TimingArcSet *set)
+{
+  const TimingModel *m0 = set->model(RiseFall::rise());
+  const TimingModel *m1 = set->model(RiseFall::fall());
+  bool internable = (m0 != nullptr || m1 != nullptr);
+
+  if (internable) {
+    auto key = std::make_pair(m0, m1);
+    auto it = attrs_ids_.find(key);
+    if (it != attrs_ids_.end()) {
+      w_.u32(it->second);
+      return;
+    }
+    uint32_t id = static_cast<uint32_t>(attrs_ids_.size());
+    attrs_ids_[key] = id;
+    w_.u32(id);
+  }
+  else
+    w_.u32(kNullId);
+
+  w_.u8(static_cast<uint8_t>(set->timingType()));
+  w_.u8(static_cast<uint8_t>(set->sense()));
+  writeFuncExpr(set->cond());
+  w_.str(set->sdfCondStart());
+  w_.str(set->sdfCondEnd());
+  w_.str(set->modeName());
+  w_.str(set->modeValue());
+  writeModel(m0);
+  writeModel(m1);
+}
+
+void
+LibWriter::writeArcSet(TimingArcSet *set)
+{
+  writePortRef(set->from());
+  writePortRef(set->to());
+  writePortRef(set->relatedOut());
+  w_.str(set->role()->to_string());
+  writeAttrs(set);
+
+  const TimingArcSeq &arcs = set->arcs();
+  w_.u32(static_cast<uint32_t>(arcs.size()));
+  for (const TimingArc *arc : arcs) {
+    w_.str(arc->fromEdge()->to_string());
+    w_.str(arc->toEdge()->to_string());
+    // An arc's model is always one of the two attrs models, so store the slot
+    // rather than the model, which keeps the sharing intact on reload.
+    const TimingModel *model = arc->model();
+    uint8_t slot = 0xFF;
+    if (model != nullptr && model == set->model(RiseFall::rise()))
+      slot = 0;
+    else if (model != nullptr && model == set->model(RiseFall::fall()))
+      slot = 1;
+    w_.u8(slot);
+  }
+}
+
+////////////////////////////////////////////////////////////////
+
+void
+LibWriter::writeRiseFallMinMax(const LibertyPort *port)
+{
+  for (const RiseFall *rf : RiseFall::range()) {
+    for (const MinMax *mm : MinMax::range()) {
+      float value;
+      bool exists;
+      port->capacitance(rf, mm, value, exists);
+      w_.boolean(exists);
+      w_.f32(exists ? value : 0.0F);
+    }
+  }
+}
+
+void
+LibWriter::writeMinMaxLimit(const LibertyPort *port,
+                            void (LibertyPort::*getter)(const MinMax *, float &,
+                                                        bool &) const)
+{
+  for (const MinMax *mm : MinMax::range()) {
+    float value;
+    bool exists;
+    (port->*getter)(mm, value, exists);
+    w_.boolean(exists);
+    w_.f32(exists ? value : 0.0F);
+  }
+}
+
+void
+LibWriter::writePortAttrs(LibertyPort *port)
+{
+  w_.u8(directionCode(port->direction()));
+  writeRiseFallMinMax(port);
+  writeMinMaxLimit(port, &LibertyPort::slewLimit);
+  writeMinMaxLimit(port, &LibertyPort::capacitanceLimit);
+  writeMinMaxLimit(port, &LibertyPort::fanoutLimit);
+
+  float value;
+  bool exists;
+  port->fanoutLoad(value, exists);
+  w_.boolean(exists);
+  w_.f32(exists ? value : 0.0F);
+
+  port->minPeriod(value, exists);
+  w_.boolean(exists);
+  w_.f32(exists ? value : 0.0F);
+
+  for (const RiseFall *rf : RiseFall::range()) {
+    port->minPulseWidth(rf, value, exists);
+    w_.boolean(exists);
+    w_.f32(exists ? value : 0.0F);
+  }
+
+  w_.boolean(port->isClock());
+  w_.boolean(port->isClockGateClock());
+  w_.boolean(port->isClockGateEnable());
+  w_.boolean(port->isClockGateOut());
+  w_.boolean(port->isPllFeedback());
+  w_.boolean(port->isolationCellData());
+  w_.boolean(port->isolationCellEnable());
+  w_.boolean(port->levelShifterData());
+  w_.boolean(port->isSwitch());
+  w_.boolean(port->isPad());
+
+  w_.u8(static_cast<uint8_t>(port->pwrGndType()));
+  w_.str(port->voltageName());
+  w_.u8(static_cast<uint8_t>(port->scanSignalType()));
+
+  const RiseFall *trigger = port->pulseClkTrigger();
+  const RiseFall *sense = port->pulseClkSense();
+  w_.boolean(trigger != nullptr);
+  if (trigger) {
+    w_.u8(static_cast<uint8_t>(trigger->index()));
+    w_.u8(static_cast<uint8_t>(sense ? sense->index() : 0));
+  }
+
+  writeFuncExpr(port->function());
+  writeFuncExpr(port->tristateEnable());
+  writePortRef(port->relatedPowerPort());
+  writePortRef(port->relatedGroundPort());
+}
+
+void
+LibWriter::writePort(LibertyPort *port)
+{
+  w_.str(port->name());
+  if (port->isBus()) {
+    w_.u8(static_cast<uint8_t>(PortKind::bus));
+    w_.i32(port->fromIndex());
+    w_.i32(port->toIndex());
+    // LibertyCell exposes no iterator over its local bus declarations, so the
+    // declaration is stored inline and recreated on demand at load.
+    BusDcl *dcl = port->busDcl();
+    w_.boolean(dcl != nullptr);
+    if (dcl) {
+      w_.str(dcl->name());
+      w_.i32(dcl->from());
+      w_.i32(dcl->to());
+    }
+  }
+  else if (port->isBundle()) {
+    w_.u8(static_cast<uint8_t>(PortKind::bundle));
+    LibertyPortMemberIterator member_iter(port);
+    std::vector<LibertyPort *> members;
+    while (member_iter.hasNext())
+      members.push_back(member_iter.next());
+    w_.u32(static_cast<uint32_t>(members.size()));
+    for (LibertyPort *member : members)
+      w_.str(member->name());
+  }
+  else
+    w_.u8(static_cast<uint8_t>(PortKind::scalar));
+}
+
+////////////////////////////////////////////////////////////////
+
+void
+LibWriter::writeCell(LibertyCell *cell)
+{
+  w_.str(cell->name());
+  w_.str(cell->filename());
+  w_.f32(cell->area());
+  w_.boolean(cell->dontUse());
+  w_.boolean(cell->isMacro());
+  w_.boolean(cell->isMemory());
+  w_.boolean(cell->isPad());
+  w_.boolean(cell->isClockCell());
+  w_.boolean(cell->isLevelShifter());
+  w_.u8(static_cast<uint8_t>(cell->levelShifterType()));
+  w_.boolean(cell->isIsolationCell());
+  w_.boolean(cell->alwaysOn());
+  w_.u8(static_cast<uint8_t>(cell->switchCellType()));
+  w_.boolean(cell->interfaceTiming());
+  w_.str(cell->footprint());
+  w_.str(cell->userFunctionClass());
+  w_.f32(cell->ocvArcDepth());
+  // inferLatchRoles() only runs when this is set, and it is what lets
+  // makeLatchEnables() rebuild latch_enables_ from the reloaded roles.
+  w_.boolean(cell->hasInferedRegTimingArcs());
+
+  ClockGateType cg = ClockGateType::none;
+  if (cell->isClockGateLatchPosedge()) cg = ClockGateType::latch_posedge;
+  else if (cell->isClockGateLatchNegedge()) cg = ClockGateType::latch_negedge;
+  else if (cell->isClockGateOther()) cg = ClockGateType::other;
+  w_.u8(static_cast<uint8_t>(cg));
+
+  ScaleFactors *sf = cell->scaleFactors();
+  w_.boolean(sf != nullptr);
+  if (sf)
+    w_.str(sf->name());
+
+  // Port creation order drives pin_index_ and therefore the per-instance pin
+  // array layout, so the ordered port list is written, not the name map.
+  std::vector<LibertyPort *> ports;
+  LibertyCellPortIterator port_iter(cell);
+  while (port_iter.hasNext())
+    ports.push_back(port_iter.next());
+
+  w_.u32(static_cast<uint32_t>(ports.size()));
+  for (LibertyPort *port : ports)
+    writePort(port);
+
+  // Attributes come after every port exists, so functions can reference ports
+  // declared later in the cell. Containers are written before bits because
+  // setting a bus attribute propagates to its members, and the bit's own
+  // value has to be the one that lands last.
+  std::vector<LibertyPort *> bits;
+  LibertyCellPortBitIterator bit_iter(cell);
+  while (bit_iter.hasNext())
+    bits.push_back(bit_iter.next());
+
+  w_.u32(static_cast<uint32_t>(ports.size() + bits.size()));
+  for (LibertyPort *port : ports) {
+    w_.str(port->name());
+    writePortAttrs(port);
+  }
+  for (LibertyPort *port : bits) {
+    w_.str(port->name());
+    writePortAttrs(port);
+  }
+
+  const SequentialSeq &seqs = cell->sequentials();
+  w_.u32(static_cast<uint32_t>(seqs.size()));
+  for (const Sequential &seq : seqs) {
+    w_.boolean(seq.isRegister());
+    writeFuncExpr(seq.clock());
+    writeFuncExpr(seq.data());
+    writeFuncExpr(seq.clear());
+    writeFuncExpr(seq.preset());
+    w_.u8(static_cast<uint8_t>(seq.clearPresetOutput()));
+    w_.u8(static_cast<uint8_t>(seq.clearPresetOutputInv()));
+    writePortRef(seq.output());
+    writePortRef(seq.outputInv());
+  }
+
+  // Statetables are the other source of isSequential(): sky130's clock gating
+  // latches are described this way rather than with a latch group.
+  const Statetable *statetable = cell->statetable();
+  w_.boolean(statetable != nullptr);
+  if (statetable) {
+    const LibertyPortSeq &inputs = statetable->inputPorts();
+    w_.u32(static_cast<uint32_t>(inputs.size()));
+    for (const LibertyPort *port : inputs)
+      writePortRef(port);
+    const LibertyPortSeq &internals = statetable->internalPorts();
+    w_.u32(static_cast<uint32_t>(internals.size()));
+    for (const LibertyPort *port : internals)
+      writePortRef(port);
+
+    const StatetableRows &rows = statetable->table();
+    w_.u32(static_cast<uint32_t>(rows.size()));
+    for (const StatetableRow &row : rows) {
+      w_.u32(static_cast<uint32_t>(row.inputValues().size()));
+      for (StateInputValue v : row.inputValues())
+        w_.u8(static_cast<uint8_t>(v));
+      w_.u32(static_cast<uint32_t>(row.currentValues().size()));
+      for (StateInternalValue v : row.currentValues())
+        w_.u8(static_cast<uint8_t>(v));
+      w_.u32(static_cast<uint32_t>(row.nextValues().size()));
+      for (StateInternalValue v : row.nextValues())
+        w_.u8(static_cast<uint8_t>(v));
+    }
+  }
+
+  const GeneratedClockSeq &gen_clks = cell->generatedClocks();
+  w_.u32(static_cast<uint32_t>(gen_clks.size()));
+  for (const GeneratedClock *gc : gen_clks) {
+    w_.str(gc->name());
+    w_.str(gc->clockPin());
+    w_.str(gc->masterPin());
+    w_.i32(gc->dividedBy());
+    w_.i32(gc->multipliedBy());
+    w_.f32(gc->dutyCycle());
+    w_.boolean(gc->invert());
+    const IntSeq *edges = gc->edges();
+    w_.u32(edges ? static_cast<uint32_t>(edges->size()) : 0);
+    if (edges)
+      for (int edge : *edges)
+        w_.i32(edge);
+    const FloatSeq *shifts = gc->edgeShifts();
+    static const FloatSeq empty;
+    w_.floats(shifts ? *shifts : empty);
+  }
+
+  // Arc set order defines TimingArcSet::index_, which makeSceneMap uses to
+  // align corners, so the sequence is written verbatim.
+  const TimingArcSetSeq &arc_sets = cell->timingArcSets();
+  w_.u32(static_cast<uint32_t>(arc_sets.size()));
+  for (TimingArcSet *set : arc_sets)
+    writeArcSet(set);
+}
+
+////////////////////////////////////////////////////////////////
+
+void
+LibWriter::writeUnit(const Unit *unit)
+{
+  w_.f32(unit->scale());
+  w_.str(unit->suffix());
+  w_.i32(unit->digits());
+}
+
+void
+LibWriter::writeLibrary()
+{
+  w_.str(lib_->name());
+  w_.str(lib_->filename());
+  w_.u8(static_cast<uint8_t>(lib_->delayModelType()));
+  w_.u8(static_cast<uint8_t>(lib_->busBrktLeft()));
+  w_.u8(static_cast<uint8_t>(lib_->busBrktRight()));
+
+  const Units *units = lib_->units();
+  writeUnit(units->timeUnit());
+  writeUnit(units->capacitanceUnit());
+  writeUnit(units->voltageUnit());
+  writeUnit(units->resistanceUnit());
+  writeUnit(units->currentUnit());
+  writeUnit(units->powerUnit());
+  writeUnit(units->distanceUnit());
+  writeUnit(units->scalarUnit());
+
+  w_.f32(lib_->nominalProcess());
+  w_.f32(lib_->nominalVoltage());
+  w_.f32(lib_->nominalTemperature());
+  w_.f32(lib_->defaultInputPinCap());
+  w_.f32(lib_->defaultOutputPinCap());
+  w_.f32(lib_->defaultBidirectPinCap());
+
+  float value;
+  bool exists;
+  for (const RiseFall *rf : RiseFall::range()) {
+    lib_->defaultIntrinsic(rf, value, exists);
+    w_.boolean(exists);
+    w_.f32(exists ? value : 0.0F);
+  }
+  for (const RiseFall *rf : RiseFall::range()) {
+    lib_->defaultBidirectPinRes(rf, value, exists);
+    w_.boolean(exists);
+    w_.f32(exists ? value : 0.0F);
+  }
+  for (const RiseFall *rf : RiseFall::range()) {
+    lib_->defaultOutputPinRes(rf, value, exists);
+    w_.boolean(exists);
+    w_.f32(exists ? value : 0.0F);
+  }
+
+  lib_->defaultFanoutLoad(value, exists);
+  w_.boolean(exists);
+  w_.f32(exists ? value : 0.0F);
+  lib_->defaultMaxCapacitance(value, exists);
+  w_.boolean(exists);
+  w_.f32(exists ? value : 0.0F);
+  lib_->defaultMaxFanout(value, exists);
+  w_.boolean(exists);
+  w_.f32(exists ? value : 0.0F);
+  lib_->defaultMaxSlew(value, exists);
+  w_.boolean(exists);
+  w_.f32(exists ? value : 0.0F);
+
+  for (const RiseFall *rf : RiseFall::range()) w_.f32(lib_->inputThreshold(rf));
+  for (const RiseFall *rf : RiseFall::range()) w_.f32(lib_->outputThreshold(rf));
+  for (const RiseFall *rf : RiseFall::range()) w_.f32(lib_->slewLowerThreshold(rf));
+  for (const RiseFall *rf : RiseFall::range()) w_.f32(lib_->slewUpperThreshold(rf));
+  w_.f32(lib_->slewDerateFromLibrary());
+  w_.f32(lib_->ocvArcDepth());
+
+  BusDclSeq bus_dcls = lib_->busDcls();
+  w_.u32(static_cast<uint32_t>(bus_dcls.size()));
+  for (BusDcl *dcl : bus_dcls) {
+    w_.str(dcl->name());
+    w_.i32(dcl->from());
+    w_.i32(dcl->to());
+  }
+
+  TableTemplateSeq templates = lib_->tableTemplates();
+  w_.u32(static_cast<uint32_t>(templates.size()));
+  for (TableTemplate *tmpl : templates) {
+    w_.str(tmpl->name());
+    w_.u8(static_cast<uint8_t>(tmpl->type()));
+    writeAxisRef(tmpl->axis1ptr());
+    writeAxisRef(tmpl->axis2ptr());
+    writeAxisRef(tmpl->axis3ptr());
+  }
+
+  // Only the default operating conditions and scale factors are stored:
+  // LibertyLibrary exposes no iterator over the named maps, so non-default
+  // entries would need a new accessor. They only matter under
+  // set_operating_conditions with a named corner.
+  OperatingConditions *op_cond = lib_->defaultOperatingConditions();
+  w_.boolean(op_cond != nullptr);
+  if (op_cond) {
+    w_.str(op_cond->name());
+    w_.f32(op_cond->process());
+    w_.f32(op_cond->voltage());
+    w_.f32(op_cond->temperature());
+    w_.u8(static_cast<uint8_t>(op_cond->wireloadTree()));
+  }
+
+  ScaleFactors *scales = lib_->scaleFactors();
+  w_.boolean(scales != nullptr);
+  if (scales) {
+    w_.str(scales->name());
+    for (int type = 0; type < scale_factor_type_count; type++) {
+      for (int pvt = 0; pvt < scale_factor_pvt_count; pvt++) {
+        for (const RiseFall *rf : RiseFall::range())
+          w_.f32(scales->scale(static_cast<ScaleFactorType>(type),
+                               static_cast<ScaleFactorPvt>(pvt), rf));
+      }
+    }
+  }
+
+  LibertyCellIterator cell_iter(lib_);
+  std::vector<LibertyCell *> cells;
+  while (cell_iter.hasNext())
+    cells.push_back(cell_iter.next());
+  w_.u32(static_cast<uint32_t>(cells.size()));
+  for (LibertyCell *cell : cells)
+    writeCell(cell);
+}
+
+void
+LibWriter::write(const char *path)
+{
+  writeLibrary();
+
+  FILE *f = fopen(path, "wb");
+  if (f == nullptr)
+    report_->error(1352, "cannot open {} for writing.", path);
+
+  // The string table is emitted after the body because ids are assigned on
+  // demand while serializing; the header carries both section sizes.
+  DbWriter strings;
+  for (const std::string &s : w_.strings()) {
+    strings.u32(static_cast<uint32_t>(s.size()));
+    for (char c : s)
+      strings.u8(static_cast<uint8_t>(c));
+  }
+
+  LibDbHeader hdr{};
+  std::memcpy(hdr.magic, kLibDbMagic, sizeof hdr.magic);
+  hdr.version = kLibDbVersion;
+  hdr.flags = 0;
+  hdr.infer_latches = 0;
+  hdr.pointer_size = sizeof(void *);
+  hdr.string_bytes = strings.size();
+  hdr.body_bytes = w_.size();
+
+  bool ok = fwrite(&hdr, sizeof hdr, 1, f) == 1;
+  uint32_t count = static_cast<uint32_t>(w_.strings().size());
+  ok = ok && fwrite(&count, sizeof count, 1, f) == 1;
+  if (ok && strings.size())
+    ok = fwrite(strings.bytes().data(), strings.size(), 1, f) == 1;
+  if (ok && w_.size())
+    ok = fwrite(w_.bytes().data(), w_.size(), 1, f) == 1;
+  fclose(f);
+
+  if (!ok)
+    report_->error(1353, "error writing {}.", path);
+}
+
+} // namespace
+
+void
+writeLibDbFile(LibertyLibrary *library,
+               std::string_view filename,
+               Report *report)
+{
+  if (library == nullptr)
+    report->error(1354, "no liberty library to write.");
+  std::string path(filename);
+  LibWriter writer(library, report);
+  writer.write(path.c_str());
+}
+
+} // namespace sta

--- a/liberty/LibDbWriter.cc
+++ b/liberty/LibDbWriter.cc
@@ -22,6 +22,13 @@
 // 
 // This notice may not be removed or altered from any source distribution.
 
+// write_lib_db: binary cache of one NLDM LibertyLibrary.
+//
+// File layout: [header][string_count][string table][body]
+// Body field order must match LibLoader in LibDbReader.cc.
+// Shared axes/tables/attrs: first use writes id + full data; later uses write id only.
+// Strings: body stores an index; the string table holds the text once.
+
 #include "LibDb.hh"
 
 #include <cstdio>
@@ -46,16 +53,10 @@
 
 namespace sta {
 
-namespace {
-
-constexpr uint32_t kNullId = 0xFFFFFFFFu;
-
-enum class ModelKind : uint8_t { none = 0, gate = 1, check = 2 };
-enum class PortKind : uint8_t { scalar = 0, bus = 1, bundle = 2 };
-
-uint8_t
+static uint8_t
 directionCode(const PortDirection *dir)
 {
+  // PortDirection is a pointer in RAM; store a small stable number instead.
   if (dir == PortDirection::input()) return 0;
   if (dir == PortDirection::output()) return 1;
   if (dir == PortDirection::tristate()) return 2;
@@ -67,6 +68,7 @@ directionCode(const PortDirection *dir)
   return 8;
 }
 
+// Walks a loaded library and appends body bytes via DbWriter.
 class LibWriter
 {
 public:
@@ -98,28 +100,22 @@ private:
                         void (LibertyPort::*getter)(const MinMax *, float &, bool &) const);
   void writePortRef(const LibertyPort *port);
 
-  DbWriter w_;
+  DbWriter w_;            // body bytes + unique string list
   LibertyLibrary *lib_;
   Report *report_;
+  // "Have we already written this shared object?" → reuse its number.
   std::map<const TableAxis *, uint32_t> axis_ids_;
   std::map<const Table *, uint32_t> table_ids_;
-  // Arc sets that share a TimingArcAttrs share its models, and a model is
-  // owned by exactly one attrs, so the model pointer pair identifies the
-  // attrs group without needing access to the attrs pointer itself.
   std::map<std::pair<const TimingModel *, const TimingModel *>, uint32_t> attrs_ids_;
 };
 
 ////////////////////////////////////////////////////////////////
-// Interned references.
-//
-// An id equal to the next unused id means the definition follows inline. That
-// keeps the file single-pass in both directions with no section offsets.
+// Optional port by name (flag + string), not a raw pointer.
 
 void
 LibWriter::writePortRef(const LibertyPort *port)
 {
-  // A presence flag rather than a sentinel id, because any 32-bit value is a
-  // legal string table index.
+  // Presence flag: any u32 is a legal string id, so null cannot be a sentinel.
   if (port == nullptr) {
     w_.boolean(false);
     return;
@@ -131,15 +127,17 @@ LibWriter::writePortRef(const LibertyPort *port)
 void
 LibWriter::writeAxisRef(const TableAxisPtr &axis)
 {
+  // Save each axis once. Later uses write only its number, not the full data.
   if (!axis) {
-    w_.u32(kNullId);
+    w_.u32(lib_db_id_null);
     return;
   }
   auto it = axis_ids_.find(axis.get());
   if (it != axis_ids_.end()) {
-    w_.u32(it->second);
+    w_.u32(it->second);  // already saved earlier
     return;
   }
+  // First time: assign a number, then write the full axis after it.
   uint32_t id = static_cast<uint32_t>(axis_ids_.size());
   axis_ids_[axis.get()] = id;
   w_.u32(id);
@@ -150,8 +148,9 @@ LibWriter::writeAxisRef(const TableAxisPtr &axis)
 void
 LibWriter::writeTableRef(const TablePtr &table)
 {
+  // Same share pattern as axes: null / reuse id / or id + payload.
   if (!table) {
-    w_.u32(kNullId);
+    w_.u32(lib_db_id_null);
     return;
   }
   auto it = table_ids_.find(table.get());
@@ -163,6 +162,7 @@ LibWriter::writeTableRef(const TablePtr &table)
   table_ids_[table.get()] = id;
   w_.u32(id);
 
+  // order: 0=scalar, 1=1D vector, 2/3=row-major FloatTable.
   int order = table->order();
   w_.u8(static_cast<uint8_t>(order));
   writeAxisRef(table->axis1ptr());
@@ -177,8 +177,7 @@ LibWriter::writeTableRef(const TablePtr &table)
     w_.floats(values ? *values : empty);
   }
   else {
-    // Orders 2 and 3 share one FloatTable; order 3 flattens (axis1, axis2)
-    // into the row index, so storing rows verbatim preserves both layouts.
+    // Orders 2/3 share FloatTable layout; store rows as-is.
     const FloatTable *values = table->values3();
     uint32_t rows = values ? static_cast<uint32_t>(values->size()) : 0;
     w_.u32(rows);
@@ -188,7 +187,6 @@ LibWriter::writeTableRef(const TablePtr &table)
 }
 
 ////////////////////////////////////////////////////////////////
-// Timing models.
 
 void
 LibWriter::writeTableModel(const TableModel *model)
@@ -199,6 +197,7 @@ LibWriter::writeTableModel(const TableModel *model)
   }
   w_.boolean(true);
   writeTableRef(model->table());
+  // Template by name/type (reader looks it up on the library).
   TableTemplate *tmpl = model->tblTemplate();
   if (tmpl) {
     w_.boolean(true);
@@ -219,25 +218,25 @@ LibWriter::writeTableModels(const TableModels *models)
     return;
   }
   w_.boolean(true);
-  // Only the NLDM model is stored. sigma/std_dev/mean_shift/skewness are LVF
-  // and are dropped with CCS; see kFlagHasLvf.
+  // NLDM only; LVF sigma/etc. are omitted.
   writeTableModel(models->model());
 }
 
 void
 LibWriter::writeModel(const TimingModel *model)
 {
+  // One byte kind, then delay/slew (gate) or check tables.
   if (const GateTableModel *gate = dynamic_cast<const GateTableModel *>(model)) {
-    w_.u8(static_cast<uint8_t>(ModelKind::gate));
+    w_.u8(static_cast<uint8_t>(LibDbModelKind::gate));
     writeTableModels(gate->delayModels());
     writeTableModels(gate->slewModels());
   }
   else if (const CheckTableModel *check = dynamic_cast<const CheckTableModel *>(model)) {
-    w_.u8(static_cast<uint8_t>(ModelKind::check));
+    w_.u8(static_cast<uint8_t>(LibDbModelKind::check));
     writeTableModels(check->checkModels());
   }
   else
-    w_.u8(static_cast<uint8_t>(ModelKind::none));
+    w_.u8(static_cast<uint8_t>(LibDbModelKind::none));
 }
 
 ////////////////////////////////////////////////////////////////
@@ -245,6 +244,7 @@ LibWriter::writeModel(const TimingModel *model)
 void
 LibWriter::writeFuncExpr(const FuncExpr *expr)
 {
+  // Recursive: 0xFF = null; port leaf; else op then left and right (both always written).
   if (expr == nullptr) {
     w_.u8(0xFF);
     return;
@@ -261,23 +261,26 @@ LibWriter::writeFuncExpr(const FuncExpr *expr)
 void
 LibWriter::writeAttrs(TimingArcSet *set)
 {
+  // Attrs blob shared by rise/fall model pointer pair; id or full fields + models.
   const TimingModel *m0 = set->model(RiseFall::rise());
   const TimingModel *m1 = set->model(RiseFall::fall());
-  bool internable = (m0 != nullptr || m1 != nullptr);
+  bool can_share = (m0 != nullptr || m1 != nullptr);
 
-  if (internable) {
+  // Many arc sets share one attrs object; write the full blob only once.
+  if (can_share) {
     auto key = std::make_pair(m0, m1);
     auto it = attrs_ids_.find(key);
     if (it != attrs_ids_.end()) {
       w_.u32(it->second);
-      return;
+      return;  // already wrote the full attrs for this number
     }
     uint32_t id = static_cast<uint32_t>(attrs_ids_.size());
     attrs_ids_[key] = id;
     w_.u32(id);
   }
   else
-    w_.u32(kNullId);
+    // id_null means "no shared attrs id" (both models null); still write fields below.
+    w_.u32(lib_db_id_null);
 
   w_.u8(static_cast<uint8_t>(set->timingType()));
   w_.u8(static_cast<uint8_t>(set->sense()));
@@ -293,19 +296,19 @@ LibWriter::writeAttrs(TimingArcSet *set)
 void
 LibWriter::writeArcSet(TimingArcSet *set)
 {
+  // from/to/related_out, role name, attrs, then each TimingArc edge pair + model slot.
   writePortRef(set->from());
   writePortRef(set->to());
   writePortRef(set->relatedOut());
   w_.str(set->role()->to_string());
   writeAttrs(set);
 
+  // Each arc: edge names + which attrs model to use (0=rise, 1=fall, 0xFF=none).
   const TimingArcSeq &arcs = set->arcs();
   w_.u32(static_cast<uint32_t>(arcs.size()));
   for (const TimingArc *arc : arcs) {
     w_.str(arc->fromEdge()->to_string());
     w_.str(arc->toEdge()->to_string());
-    // An arc's model is always one of the two attrs models, so store the slot
-    // rather than the model, which keeps the sharing intact on reload.
     const TimingModel *model = arc->model();
     uint8_t slot = 0xFF;
     if (model != nullptr && model == set->model(RiseFall::rise()))
@@ -321,6 +324,7 @@ LibWriter::writeArcSet(TimingArcSet *set)
 void
 LibWriter::writeRiseFallMinMax(const LibertyPort *port)
 {
+  // Always write (exists, value) so the stream stays fixed-shape.
   for (const RiseFall *rf : RiseFall::range()) {
     for (const MinMax *mm : MinMax::range()) {
       float value;
@@ -349,6 +353,7 @@ LibWriter::writeMinMaxLimit(const LibertyPort *port,
 void
 LibWriter::writePortAttrs(LibertyPort *port)
 {
+  // Caps, limits, clock/iso/level-shifter flags, functions, related pg ports.
   w_.u8(directionCode(port->direction()));
   writeRiseFallMinMax(port);
   writeMinMaxLimit(port, &LibertyPort::slewLimit);
@@ -403,13 +408,13 @@ LibWriter::writePortAttrs(LibertyPort *port)
 void
 LibWriter::writePort(LibertyPort *port)
 {
+  // Structure only (name + kind). Attributes come later in writePortAttrs.
   w_.str(port->name());
   if (port->isBus()) {
-    w_.u8(static_cast<uint8_t>(PortKind::bus));
+    w_.u8(static_cast<uint8_t>(LibDbPortKind::bus));
     w_.i32(port->fromIndex());
     w_.i32(port->toIndex());
-    // LibertyCell exposes no iterator over its local bus declarations, so the
-    // declaration is stored inline and recreated on demand at load.
+    // No cell bus-dcl iterator; store declaration inline.
     BusDcl *dcl = port->busDcl();
     w_.boolean(dcl != nullptr);
     if (dcl) {
@@ -419,7 +424,7 @@ LibWriter::writePort(LibertyPort *port)
     }
   }
   else if (port->isBundle()) {
-    w_.u8(static_cast<uint8_t>(PortKind::bundle));
+    w_.u8(static_cast<uint8_t>(LibDbPortKind::bundle));
     LibertyPortMemberIterator member_iter(port);
     std::vector<LibertyPort *> members;
     while (member_iter.hasNext())
@@ -429,7 +434,7 @@ LibWriter::writePort(LibertyPort *port)
       w_.str(member->name());
   }
   else
-    w_.u8(static_cast<uint8_t>(PortKind::scalar));
+    w_.u8(static_cast<uint8_t>(LibDbPortKind::scalar));
 }
 
 ////////////////////////////////////////////////////////////////
@@ -437,6 +442,7 @@ LibWriter::writePort(LibertyPort *port)
 void
 LibWriter::writeCell(LibertyCell *cell)
 {
+  // --- identity / flags ---
   w_.str(cell->name());
   w_.str(cell->filename());
   w_.f32(cell->area());
@@ -454,8 +460,7 @@ LibWriter::writeCell(LibertyCell *cell)
   w_.str(cell->footprint());
   w_.str(cell->userFunctionClass());
   w_.f32(cell->ocvArcDepth());
-  // inferLatchRoles() only runs when this is set, and it is what lets
-  // makeLatchEnables() rebuild latch_enables_ from the reloaded roles.
+  // Needed so finish() can rebuild latch_enables_ from reloaded roles.
   w_.boolean(cell->hasInferedRegTimingArcs());
 
   ClockGateType cg = ClockGateType::none;
@@ -469,8 +474,7 @@ LibWriter::writeCell(LibertyCell *cell)
   if (sf)
     w_.str(sf->name());
 
-  // Port creation order drives pin_index_ and therefore the per-instance pin
-  // array layout, so the ordered port list is written, not the name map.
+  // --- ports: create structure first (order sets pin_index_) ---
   std::vector<LibertyPort *> ports;
   LibertyCellPortIterator port_iter(cell);
   while (port_iter.hasNext())
@@ -480,10 +484,8 @@ LibWriter::writeCell(LibertyCell *cell)
   for (LibertyPort *port : ports)
     writePort(port);
 
-  // Attributes come after every port exists, so functions can reference ports
-  // declared later in the cell. Containers are written before bits because
-  // setting a bus attribute propagates to its members, and the bit's own
-  // value has to be the one that lands last.
+  // --- then attrs (all ports exist so functions can name later pins) ---
+  // Containers before bits so bit values win over bus propagation.
   std::vector<LibertyPort *> bits;
   LibertyCellPortBitIterator bit_iter(cell);
   while (bit_iter.hasNext())
@@ -499,6 +501,7 @@ LibWriter::writeCell(LibertyCell *cell)
     writePortAttrs(port);
   }
 
+  // --- registers/latches, optional state table, generated clocks, then timing arcs ---
   const SequentialSeq &seqs = cell->sequentials();
   w_.u32(static_cast<uint32_t>(seqs.size()));
   for (const Sequential &seq : seqs) {
@@ -513,8 +516,7 @@ LibWriter::writeCell(LibertyCell *cell)
     writePortRef(seq.outputInv());
   }
 
-  // Statetables are the other source of isSequential(): sky130's clock gating
-  // latches are described this way rather than with a latch group.
+  // Statetable also marks isSequential() (e.g. some clock-gate latches).
   const Statetable *statetable = cell->statetable();
   w_.boolean(statetable != nullptr);
   if (statetable) {
@@ -562,8 +564,7 @@ LibWriter::writeCell(LibertyCell *cell)
     w_.floats(shifts ? *shifts : empty);
   }
 
-  // Arc set order defines TimingArcSet::index_, which makeSceneMap uses to
-  // align corners, so the sequence is written verbatim.
+  // --- timing (order = TimingArcSet::index_ for scene maps) ---
   const TimingArcSetSeq &arc_sets = cell->timingArcSets();
   w_.u32(static_cast<uint32_t>(arc_sets.size()));
   for (TimingArcSet *set : arc_sets)
@@ -583,6 +584,7 @@ LibWriter::writeUnit(const Unit *unit)
 void
 LibWriter::writeLibrary()
 {
+  // Globals → units → defaults → bus dcls → templates → default op-cond/scales → cells.
   w_.str(lib_->name());
   w_.str(lib_->filename());
   w_.u8(static_cast<uint8_t>(lib_->delayModelType()));
@@ -606,6 +608,7 @@ LibWriter::writeLibrary()
   w_.f32(lib_->defaultOutputPinCap());
   w_.f32(lib_->defaultBidirectPinCap());
 
+  // Optional library defaults: (exists, value) pairs.
   float value;
   bool exists;
   for (const RiseFall *rf : RiseFall::range()) {
@@ -652,6 +655,7 @@ LibWriter::writeLibrary()
     w_.i32(dcl->to());
   }
 
+  // Templates (and their axes) before cells that reference them.
   TableTemplateSeq templates = lib_->tableTemplates();
   w_.u32(static_cast<uint32_t>(templates.size()));
   for (TableTemplate *tmpl : templates) {
@@ -662,10 +666,7 @@ LibWriter::writeLibrary()
     writeAxisRef(tmpl->axis3ptr());
   }
 
-  // Only the default operating conditions and scale factors are stored:
-  // LibertyLibrary exposes no iterator over the named maps, so non-default
-  // entries would need a new accessor. They only matter under
-  // set_operating_conditions with a named corner.
+  // Default op-cond / scale factors only (no named-map iterators).
   OperatingConditions *op_cond = lib_->defaultOperatingConditions();
   w_.boolean(op_cond != nullptr);
   if (op_cond) {
@@ -701,14 +702,16 @@ LibWriter::writeLibrary()
 void
 LibWriter::write(const char *path)
 {
+  // Build the body in memory. Every w_.str("...") adds to the unique-string
+  // list and writes only a number into the body.
   writeLibrary();
 
   FILE *f = fopen(path, "wb");
   if (f == nullptr)
     report_->error(1352, "cannot open {} for writing.", path);
 
-  // The string table is emitted after the body because ids are assigned on
-  // demand while serializing; the header carries both section sizes.
+  // Pack unique strings as (length, characters) so the reader can rebuild
+  // the string list before reading the body.
   DbWriter strings;
   for (const std::string &s : w_.strings()) {
     strings.u32(static_cast<uint32_t>(s.size()));
@@ -716,12 +719,9 @@ LibWriter::write(const char *path)
       strings.u8(static_cast<uint8_t>(c));
   }
 
+  // fopen + fwrite: [header][string_count][string bytes][body bytes]
   LibDbHeader hdr{};
-  std::memcpy(hdr.magic, kLibDbMagic, sizeof hdr.magic);
-  hdr.version = kLibDbVersion;
-  hdr.flags = 0;
-  hdr.infer_latches = 0;
-  hdr.pointer_size = sizeof(void *);
+  hdr.version = lib_db_version;
   hdr.string_bytes = strings.size();
   hdr.body_bytes = w_.size();
 
@@ -738,15 +738,16 @@ LibWriter::write(const char *path)
     report_->error(1353, "error writing {}.", path);
 }
 
-} // namespace
-
 void
 writeLibDbFile(LibertyLibrary *library,
                std::string_view filename,
                Report *report)
 {
+  // Public entry from Sta::writeLibDb / write_lib_db.
   if (library == nullptr)
     report->error(1354, "no liberty library to write.");
+  if (!filename.ends_with(".libdb"))
+    report->error(1357, "{} must end with .libdb.", filename);
   std::string path(filename);
   LibWriter writer(library, report);
   writer.write(path.c_str());

--- a/liberty/Liberty.i
+++ b/liberty/Liberty.i
@@ -131,6 +131,23 @@ write_liberty_cmd(LibertyLibrary *library,
   writeLiberty(library, filename, Sta::sta());
 }
 
+bool
+read_lib_db_cmd(char *filename,
+                Scene *scene,
+                const MinMaxAll *min_max)
+{
+  Sta *sta = Sta::sta();
+  LibertyLibrary *lib = sta->readLibDb(filename, scene, min_max);
+  return (lib != nullptr);
+}
+
+void
+write_lib_db_cmd(LibertyLibrary *library,
+                 char *filename)
+{
+  Sta::sta()->writeLibDb(library, filename);
+}
+
 void
 make_equiv_cells(LibertyLibrary *lib)
 {

--- a/liberty/Liberty.i
+++ b/liberty/Liberty.i
@@ -132,12 +132,10 @@ write_liberty_cmd(LibertyLibrary *library,
 }
 
 bool
-read_lib_db_cmd(char *filename,
-                Scene *scene,
-                const MinMaxAll *min_max)
+read_lib_db_cmd(char *filename)
 {
   Sta *sta = Sta::sta();
-  LibertyLibrary *lib = sta->readLibDb(filename, scene, min_max);
+  LibertyLibrary *lib = sta->readLibDb(filename);
   return (lib != nullptr);
 }
 

--- a/liberty/Liberty.tcl
+++ b/liberty/Liberty.tcl
@@ -52,17 +52,12 @@ proc write_liberty { args } {
 
 ################################################################
 
-# No -infer_latches: the arcs it would infer are already resolved in the db.
-define_cmd_args "read_lib_db" {[-corner corner] [-min] [-max] filename}
+define_cmd_args "read_lib_db" {filename}
 
 proc_redirect read_lib_db {
-  parse_key_args "read_lib_db" args keys {-corner} flags {-min -max}
   check_argc_eq1 "read_lib_db" $args
-
   set filename [file nativename [lindex $args 0]]
-  set corner [parse_scene keys]
-  set min_max [parse_min_max_all_flags flags]
-  read_lib_db_cmd $filename $corner $min_max
+  read_lib_db_cmd $filename
 }
 
 define_cmd_args "write_lib_db" {library filename}

--- a/liberty/Liberty.tcl
+++ b/liberty/Liberty.tcl
@@ -52,6 +52,31 @@ proc write_liberty { args } {
 
 ################################################################
 
+# No -infer_latches: the arcs it would infer are already resolved in the db.
+define_cmd_args "read_lib_db" {[-corner corner] [-min] [-max] filename}
+
+proc_redirect read_lib_db {
+  parse_key_args "read_lib_db" args keys {-corner} flags {-min -max}
+  check_argc_eq1 "read_lib_db" $args
+
+  set filename [file nativename [lindex $args 0]]
+  set corner [parse_scene keys]
+  set min_max [parse_min_max_all_flags flags]
+  read_lib_db_cmd $filename $corner $min_max
+}
+
+define_cmd_args "write_lib_db" {library filename}
+
+proc write_lib_db { args } {
+  check_argc_eq2 "write_lib_db" $args
+
+  set library [get_liberty_error "library" [lindex $args 0]]
+  set filename [file nativename [lindex $args 1]]
+  write_lib_db_cmd $library $filename
+}
+
+################################################################
+
 define_cmd_args "report_lib_cell" {cell_name [> filename] [>> filename]}
 
 proc_redirect report_lib_cell {

--- a/search/Sta.cc
+++ b/search/Sta.cc
@@ -101,6 +101,7 @@
 #include "VerilogReader.hh"
 #include "VisitPathEnds.hh"
 #include "Wireload.hh"
+#include "liberty/LibDb.hh"
 #include "liberty/LibertyReader.hh"
 #include "parasitics/ConcreteParasitics.hh"
 #include "parasitics/ReportParasiticAnnotation.hh"
@@ -707,6 +708,34 @@ Sta::readLiberty(std::string_view filename,
   }
   stats.report("Read liberty");
   return library;
+}
+
+LibertyLibrary *
+Sta::readLibDb(std::string_view filename,
+               Scene *scene,
+               const MinMaxAll *min_max)
+{
+  Stats stats(debug_, report_);
+  LibertyLibrary *library = sta::readLibDbFile(filename, network_);
+  if (library) {
+    readLibertyAfter(library, scene, min_max);
+    network_->readLibertyAfter(library);
+    if (network_->defaultLibertyLibrary() == nullptr) {
+      network_->setDefaultLibertyLibrary(library);
+      *units_ = *library->units();
+    }
+  }
+  stats.report("Read liberty database");
+  return library;
+}
+
+void
+Sta::writeLibDb(LibertyLibrary *library,
+                std::string_view filename)
+{
+  Stats stats(debug_, report_);
+  writeLibDbFile(library, filename, report_);
+  stats.report("Wrote liberty database");
 }
 
 LibertyLibrary *

--- a/search/Sta.cc
+++ b/search/Sta.cc
@@ -711,14 +711,12 @@ Sta::readLiberty(std::string_view filename,
 }
 
 LibertyLibrary *
-Sta::readLibDb(std::string_view filename,
-               Scene *scene,
-               const MinMaxAll *min_max)
+Sta::readLibDb(std::string_view filename)
 {
   Stats stats(debug_, report_);
   LibertyLibrary *library = sta::readLibDbFile(filename, network_);
   if (library) {
-    readLibertyAfter(library, scene, min_max);
+    readLibertyAfter(library, cmdScene(), MinMaxAll::all());
     network_->readLibertyAfter(library);
     if (network_->defaultLibertyLibrary() == nullptr) {
       network_->setDefaultLibertyLibrary(library);


### PR DESCRIPTION
### How `.libdb` works

`.libdb` is a binary cache of one already-parsed NLDM `LibertyLibrary`. It is not Liberty text. Offline: `read_liberty` → `write_lib_db`. Runtime: `read_lib_db` rebuilds the same in-memory liberty objects STA uses after `read_liberty`.

#### File layout

```text
[header: version, string_bytes, body_bytes]
[string_count]
[string table]
[body]
```

| Piece | Role |
|--------|------|
| **String table** | Each distinct string stored once as `(length, characters)` |
| **String count** | Number of string-table entries to unpack before the body |
| **Body** | Library structure and numeric data; strings are `u32` indexes into the string table |

Filename must end in `.libdb`. Native endian/floats — same CPU arch for write and read.

#### Write (`write_lib_db`)

1. Walk the loaded library in a fixed field order; append body bytes.
2. Deduplicate strings: first use adds text to the string table and writes its id; later uses write the id only.
3. Shared axes / tables / timing-arc attrs: first use writes `id + payload`; later uses write `id` only (`0xFFFFFFFF` = absent).
4. Flush: header → string table → body.

Body order: library globals → units/defaults → bus decls → table templates → default op-cond/scales → cells.  
Per cell: flags → create ports → port attrs → sequentials / state table / gen clocks → timing arcs (stored arcs, not re-inferred).

#### Read (`read_lib_db`)

1. Check `.libdb` suffix and format version; load string table and body.
2. Walk the body in the same order as the writer.
3. Rebuild with the usual liberty builders/setters (`makeLibertyLibrary`, `makeCell`, `makePort`, `makeTimingArcSet`, …).
4. Resolve shared ids to remembered objects.
5. `cell->finish(false, …)` — do not re-derive latch enables; arcs already match the original liberty.

After load, STA uses a normal `LibertyLibrary*`. Usage matches a plain liberty read:

```tcl
read_lib_db foo.libdb
```

#### Scope

NLDM only. CCS / LVF / power and non-default named op-cond/scale maps are not stored.