### PR TITLE
SDC constraint-mode aliases and sequential pin-name compatibility

### DIFF
--- a/include/sta/Network.hh
+++ b/include/sta/Network.hh
@@ -323,6 +323,10 @@ public:
   [[nodiscard]] bool isCheckClk(const Pin *pin) const;
   [[nodiscard]] bool isLatchData(const Pin *pin) const;
   [[nodiscard]] bool isLatchOutput(const Pin *pin) const;
+  // TCL variable sta_pin_name_compatibility: match CK/CLK/D/Q aliases
+  // to the sequential clock/data/Q pin on this instance.
+  bool pinNameCompatMatch(const PatternMatch *pattern,
+                          const Pin *pin) const;
 
   // Iterate over all of the pins connected to a pin and the parent
   // and child nets it is hierarchically connected to (port, leaf and

--- a/include/sta/Sta.hh
+++ b/include/sta/Sta.hh
@@ -1552,6 +1552,9 @@ public:
   // TCL variable sta_case_insensitive_matching.
   bool caseInsensitiveMatching() const;
   void setCaseInsensitiveMatching(bool enable);
+  // TCL variable sta_pin_name_compatibility.
+  bool pinNameCompatibility() const;
+  void setPinNameCompatibility(bool enable);
   ////////////////////////////////////////////////////////////////
 
   Properties &properties() { return properties_; }

--- a/include/sta/Variables.hh
+++ b/include/sta/Variables.hh
@@ -109,6 +109,12 @@ public:
   // get_* and find_*_matching commands.
   bool caseInsensitiveMatching() const { return case_insensitive_matching_; }
   void setCaseInsensitiveMatching(bool enable) { case_insensitive_matching_ = enable; }
+  // TCL variable sta_pin_name_compatibility.
+  // When a get_pins/get_db pin pattern's last component is a sequential
+  // pin alias (CK/CLK/clk/clock/CP, D/data, Q), also match the liberty
+  // register clock/data/Q pin on the same instance. Default off.
+  bool pinNameCompatibility() const { return pin_name_compatibility_; }
+  void setPinNameCompatibility(bool enable) { pin_name_compatibility_ = enable; }
 
 
 private:
@@ -137,6 +143,7 @@ private:
   bool strip_escaped_bus_{false};
   bool enable_collections_{false};
   bool case_insensitive_matching_{false};
+  bool pin_name_compatibility_{false};
 };
 
 } // namespace sta

--- a/network/Network.cc
+++ b/network/Network.cc
@@ -25,6 +25,7 @@
 
 #include <string>
 #include <iostream>
+#include <cctype>
 
 #include "Network.hh"
 #include "Sequential.hh"
@@ -40,6 +41,7 @@
 #include "PortDirection.hh"
 #include "Scene.hh"
 #include "StringUtil.hh"
+#include "Variables.hh"
 
 namespace sta {
 
@@ -78,7 +80,11 @@ Network::findPortsMatching(const Cell *cell,
   int from, to;
   parseBusName(pattern->pattern(), '[', ']', '\\',
                is_bus, is_range, bus_name, from, to, subscript_wild);
-  if (is_bus) {
+  // Patterns like nss_smu_pctrl_ubuf[*]*sbc[*] end in brackets but the
+  // "bus" name still has globs, so match full port names instead of
+  // expanding a single bus.
+  if (is_bus
+      && bus_name.find_first_of("*?") == std::string::npos) {
     PatternMatch bus_pattern(bus_name, pattern);
     CellPortIterator *port_iter = portIterator(cell);
     while (port_iter->hasNext()) {
@@ -698,6 +704,116 @@ Network::isLatchOutput(const Pin *pin) const
     return false;
 }
 
+namespace {
+
+enum class PinNameCompatRole { none, clock, data, output };
+
+// Lowercase ASCII copy of name, used only for alias-table lookup.
+std::string
+asciiLower(std::string_view name)
+{
+  std::string lower(name);
+  for (char &ch : lower)
+    ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+  return lower;
+}
+
+// Sequential pin-name families (CK/CLK/clock/CP, D/data, Q). Leading and
+// trailing glob stars on the pattern are ignored so CK* still identifies
+// the clock family.
+PinNameCompatRole
+pinNameCompatRole(std::string_view name,
+                  bool strip_globs)
+{
+  size_t begin = 0;
+  size_t end = name.size();
+  if (strip_globs) {
+    while (begin < end && (name[begin] == '*' || name[begin] == '?'))
+      begin++;
+    while (end > begin && (name[end - 1] == '*' || name[end - 1] == '?'))
+      end--;
+  }
+  std::string_view stem = name.substr(begin, end - begin);
+  // Reject remaining wildcards or path separators so C* / * / foo/CK stay
+  // out of the alias table. The last path component is extracted by the
+  // caller when needed.
+  if (stem.empty()
+      || stem.find_first_of("*?[/") != std::string_view::npos)
+    return PinNameCompatRole::none;
+  std::string lower = asciiLower(stem);
+  if (lower == "ck" || lower == "clk" || lower == "clock" || lower == "cp")
+    return PinNameCompatRole::clock;
+  if (lower == "d" || lower == "data" || lower == "din")
+    return PinNameCompatRole::data;
+  if (lower == "q")
+    return PinNameCompatRole::output;
+  return PinNameCompatRole::none;
+}
+
+bool
+isSeqDataPort(const Network *network,
+              const Pin *pin)
+{
+  if (network->isLatchData(pin))
+    return true;
+  const LibertyPort *port = network->libertyPort(pin);
+  const Instance *inst = network->instance(pin);
+  const LibertyCell *cell = inst ? network->libertyCell(inst) : nullptr;
+  if (port == nullptr || cell == nullptr)
+    return false;
+  for (const Sequential &seq : cell->sequentials()) {
+    const FuncExpr *data = seq.data();
+    if (data && data->hasPort(port))
+      return true;
+  }
+  return false;
+}
+
+bool
+isSeqOutputPort(const Network *network,
+                const Pin *pin)
+{
+  const LibertyPort *port = network->libertyPort(pin);
+  return (port && port->isRegOutput()) || network->isLatchOutput(pin);
+}
+
+} // namespace
+
+bool
+Network::pinNameCompatMatch(const PatternMatch *pattern,
+                            const Pin *pin) const
+{
+  if (pattern == nullptr || pin == nullptr || pattern->isRegexp())
+    return false;
+  const Variables *vars = variables();
+  if (vars == nullptr || !vars->pinNameCompatibility())
+    return false;
+
+  std::string head, last;
+  pathNameLast(pattern->pattern(), head, last);
+  std::string_view port_pattern = last.empty()
+    ? std::string_view(pattern->pattern())
+    : std::string_view(last);
+  PinNameCompatRole pat_role = pinNameCompatRole(port_pattern, true);
+  if (pat_role == PinNameCompatRole::none)
+    return false;
+
+  std::string port_name = portName(pin);
+  if (pinNameCompatRole(port_name, false) != pat_role)
+    return false;
+
+  switch (pat_role) {
+  case PinNameCompatRole::clock:
+    return isRegClkPin(pin);
+  case PinNameCompatRole::data:
+    return isSeqDataPort(this, pin);
+  case PinNameCompatRole::output:
+    return isSeqOutputPort(this, pin);
+  default:
+    return false;
+  }
+}
+
 ////////////////////////////////////////////////////////////////
 
 std::string
@@ -1067,12 +1183,19 @@ Network::findInstPinsHierMatching(const Instance *instance,
                                   PinSeq &matches) const
 {
   std::string inst_name(name(instance));
+  std::string head, last;
+  pathNameLast(pattern->pattern(), head, last);
+  const bool check_inst = !head.empty();
+  PatternMatch inst_pattern(head, pattern);
   InstancePinIterator *pin_iter = pinIterator(instance);
   while (pin_iter->hasNext()) {
     const Pin *pin = pin_iter->next();
     std::string port_name = name(port(pin));
     std::string pin_name = inst_name + divider_ + std::string(port_name);
-      if (pattern->match(pin_name))
+    if (pattern->match(pin_name))
+      matches.push_back(pin);
+    else if ((!check_inst || inst_pattern.match(inst_name))
+             && pinNameCompatMatch(pattern, pin))
       matches.push_back(pin);
   }
   delete pin_iter;
@@ -1087,7 +1210,7 @@ Network::findInstPinsMatching(const Instance *instance,
     InstancePinIterator *pin_iter = pinIterator(instance);
     while (pin_iter->hasNext()) {
       const Pin *pin = pin_iter->next();
-      if (pattern->match(name(pin)))
+      if (pattern->match(name(pin)) || pinNameCompatMatch(pattern, pin))
         matches.push_back(pin);
     }
     delete pin_iter;
@@ -1096,6 +1219,15 @@ Network::findInstPinsMatching(const Instance *instance,
     Pin *pin = findPin(instance, pattern->pattern());
     if (pin)
       matches.push_back(pin);
+    else if (variables() && variables()->pinNameCompatibility()) {
+      InstancePinIterator *pin_iter = pinIterator(instance);
+      while (pin_iter->hasNext()) {
+        const Pin *p = pin_iter->next();
+        if (pinNameCompatMatch(pattern, p))
+          matches.push_back(p);
+      }
+      delete pin_iter;
+    }
   }
 }
 

--- a/network/ParseBus.cc
+++ b/network/ParseBus.cc
@@ -24,12 +24,74 @@
 
 #include "ParseBus.hh"
 
+#include <cctype>
 #include <string>
 #include <string_view>
 
 #include "StringUtil.hh"
 
 namespace sta {
+
+namespace {
+
+bool
+allDigits(std::string_view s)
+{
+  if (s.empty())
+    return false;
+  size_t i = 0;
+  if (s[0] == '-' || s[0] == '+') {
+    if (s.size() == 1)
+      return false;
+    i = 1;
+  }
+  for (; i < s.size(); i++) {
+    if (!std::isdigit(static_cast<unsigned char>(s[i])))
+      return false;
+  }
+  return true;
+}
+
+// Text after the left bus bracket, including the closing bracket.
+// Returns false for glob residue such as "*]*sbc[*]".
+bool
+parseBusInside(std::string_view inside,
+               int &from,
+               int &to,
+               bool &is_range,
+               bool &subscript_wild)
+{
+  is_range = false;
+  subscript_wild = false;
+  if (inside.empty())
+    return false;
+  char last = inside.back();
+  if (last == ']' || last == '}' || last == ')')
+    inside = inside.substr(0, inside.size() - 1);
+  if (inside.empty())
+    return false;
+  if (inside == "*") {
+    subscript_wild = true;
+    return true;
+  }
+  size_t colon = inside.find(':');
+  if (colon != std::string_view::npos) {
+    std::string_view from_str = inside.substr(0, colon);
+    std::string_view to_str = inside.substr(colon + 1);
+    if (!allDigits(from_str) || !allDigits(to_str))
+      return false;
+    is_range = true;
+    from = std::stoi(std::string(from_str));
+    to = std::stoi(std::string(to_str));
+    return true;
+  }
+  if (!allDigits(inside))
+    return false;
+  from = to = std::stoi(std::string(inside));
+  return true;
+}
+
+} // namespace
 
 bool
 isBusName(std::string_view name,
@@ -87,10 +149,19 @@ parseBusName(std::string_view name,
       char brkt_left_ch = brkts_left[brkt_index];
       size_t left = name.rfind(brkt_left_ch);
       if (left != std::string_view::npos) {
-        is_bus = true;
-        bus_name.append(name.substr(0, left));
-        // Simple bus subscript.
-        index = std::stoi(std::string(name.substr(left + 1)));
+        int from = 0;
+        int to = 0;
+        bool is_range = false;
+        bool subscript_wild = false;
+        // Ranges and [*] are not a single index; leave is_bus false
+        // so callers fall back to glob matching.
+        if (parseBusInside(name.substr(left + 1), from, to, is_range,
+                           subscript_wild)
+            && !is_range && !subscript_wild) {
+          is_bus = true;
+          bus_name.append(name.substr(0, left));
+          index = from;
+        }
       }
     }
   }
@@ -141,20 +212,10 @@ parseBusName(std::string_view name,
       char brkt_left_ch = brkts_left[brkt_index];
       size_t left = name.rfind(brkt_left_ch);
       if (left != std::string_view::npos) {
-        is_bus = true;
-        bus_name.append(name.substr(0, left));
-        // Check for bus range.
-        size_t range = name.find(':', left);
-        if (range != std::string_view::npos) {
-          is_range = true;
-          from = std::stoi(std::string(name.substr(left + 1)));
-          to = std::stoi(std::string(name.substr(range + 1)));
-        }
-        else {
-          if (left + 1 < len && name[left + 1] == '*')
-            subscript_wild = true;
-          else
-            from = to = std::stoi(std::string(name.substr(left + 1)));
+        if (parseBusInside(name.substr(left + 1), from, to, is_range,
+                           subscript_wild)) {
+          is_bus = true;
+          bus_name.append(name.substr(0, left));
         }
       }
     }

--- a/network/SdcNetwork.cc
+++ b/network/SdcNetwork.cc
@@ -1053,6 +1053,8 @@ SdcNetwork::visitPinTail(const Instance *instance,
                                                           network_);
                 member_matches = tail->match(escaped_name);
               }
+              if (!member_matches)
+                member_matches = network_->pinNameCompatMatch(tail, pin);
               if (member_matches) {
                 matches.push_back(pin);
                 found_match = true;
@@ -1069,12 +1071,12 @@ SdcNetwork::visitPinTail(const Instance *instance,
                                                     network_);
           port_matches = tail->match(escaped_name);
         }
-        if (port_matches) {
-          Pin *pin = network_->findPin(instance, port);
-          if (pin) {
-            matches.push_back(pin);
-            found_match = true;
-          }
+        Pin *pin = network_->findPin(instance, port);
+        if (!port_matches)
+          port_matches = network_->pinNameCompatMatch(tail, pin);
+        if (port_matches && pin) {
+          matches.push_back(pin);
+          found_match = true;
         }
       }
     }

--- a/sdc/Variables.tcl
+++ b/sdc/Variables.tcl
@@ -243,6 +243,14 @@ proc trace_case_insensitive_matching { name1 name2 op } {
     case_insensitive_matching set_case_insensitive_matching
 }
 
+trace add variable ::sta_pin_name_compatibility {read write} \
+  sta::trace_pin_name_compatibility
+
+proc trace_pin_name_compatibility { name1 name2 op } {
+  trace_boolean_var $op ::sta_pin_name_compatibility \
+    pin_name_compatibility set_pin_name_compatibility
+}
+
 trace add variable ::sta_pocv_quantile {read write} \
   sta::trace_pocv_quantile
 

--- a/search/Property.cc
+++ b/search/Property.cc
@@ -975,6 +975,13 @@ Properties::getProperty(const Port *port,
     sta_->portExtCaps(port, MinMax::max(), sta_->cmdSdc(), cap, wire_cap, fanout);
     return capacitancePropertyValue(cap);
   }
+  else if (property == "is_clock"
+           || property == "is_clock_port"
+           || property == "is_clock_used_as_clock") {
+    const Instance *top_inst = network->topInstance();
+    const Pin *pin = network->findPin(top_inst, port);
+    return PropertyValue(pin && sta_->cmdSdc()->isClock(pin));
+  }
   else if (property == "clocks") {
     const Instance *top_inst = network->topInstance();
     const Mode *mode = sta_->cmdScene()->mode();
@@ -1230,6 +1237,16 @@ Properties::getProperty(const Pin *pin,
     return PropertyValue(network->isRegClkPin(pin));
   else if (property == "is_clock" || property == "is_clock_pin")
     return PropertyValue(network->isClock(pin));
+  else if (property == "is_clock_used_as_clock")
+    return PropertyValue(sta_->cmdSdc()->isClock(pin));
+  else if (property == "case_value") {
+    LogicValue value = LogicValue::unknown;
+    bool exists = false;
+    sta_->cmdSdc()->caseLogicValue(pin, value, exists);
+    if (!exists)
+      return PropertyValue();
+    return PropertyValue(std::string(1, logicValueString(value)));
+  }
   else if (property == "is_rise_edge_triggered")
     return PropertyValue(network->isRiseEdgeTriggered(pin));
   else if (property == "is_fall_edge_triggered")
@@ -1474,6 +1491,10 @@ Properties::getProperty(const Scene *scene,
   if (property == "name"
       || property == "full_name")
     return PropertyValue(scene->name());
+  else if (property == "is_active")
+    // analysis_views .is_active — the scene currently selected for
+    // commands (OpenSTA cmd_scene).
+    return PropertyValue(scene == sta_->cmdScene());
   else
     // Unknown properties throw PropertyUnknown; a user-defined property
     // never set on this scene returns a none value.
@@ -1489,6 +1510,13 @@ Properties::getProperty(const Mode *mode,
   if (property == "name"
       || property == "full_name")
     return PropertyValue(mode->name());
+  else if (property == "is_active")
+    // constraint_modes .is_active — the mode subsequent SDC commands
+    // write into (OpenSTA cmd_mode).
+    return PropertyValue(mode == sta_->cmdMode());
+  else if (property == "is_dynamic")
+    // Dynamic/SI constraint modes. OpenSTA has none.
+    return PropertyValue(false);
   else
     // Unknown properties throw PropertyUnknown; a user-defined property
     // never set on this mode returns a none value.

--- a/search/Search.i
+++ b/search/Search.i
@@ -39,6 +39,7 @@
 #include "Scene.hh"
 #include "Sta.hh"
 #include "StaConfig.hh"
+#include "PatternMatch.hh"
 #include "liberty/LibertyParser.hh"
 
 using namespace sta;
@@ -1296,6 +1297,32 @@ void
 set_case_insensitive_matching(bool enable)
 {
   Sta::sta()->setCaseInsensitiveMatching(enable);
+}
+
+bool
+pin_name_compatibility()
+{
+  return Sta::sta()->pinNameCompatibility();
+}
+
+void
+set_pin_name_compatibility(bool enable)
+{
+  Sta::sta()->setPinNameCompatibility(enable);
+}
+
+bool
+pin_name_compat_match(const char *pattern,
+                      const Pin *pin,
+                      bool regexp,
+                      bool nocase)
+{
+  if (pattern == nullptr || pin == nullptr)
+    return false;
+  Sta *sta = Sta::sta();
+  Network *network = sta->ensureLinked();
+  PatternMatch matcher(pattern, regexp, nocase, sta->tclInterp());
+  return network->pinNameCompatMatch(&matcher, pin);
 }
 
 %} // inline

--- a/search/Sta.cc
+++ b/search/Sta.cc
@@ -5629,6 +5629,8 @@ Sta::findFaninPins(Vertex *to,
                    int pin_level,
                    const Mode *mode)
 {
+  if (to == nullptr)
+    return;
   debugPrint(debug_, "fanin", 1, "{}", to->to_string(this));
   if (!visited.contains(to)) {
     visited.insert(to);
@@ -5680,8 +5682,12 @@ Sta::findFanoutPins(PinSeq *from,
   ensureLevelized();
   mode->sim()->ensureConstantsPropagated();
   PinSet fanout(network_);
+  if (from == nullptr)
+    return fanout;
   FanInOutSrchPred pred(thru_disabled, thru_constants, this);
   for (const Pin *pin : *from) {
+    if (pin == nullptr)
+      continue;
     if (network_->isHierarchical(pin)) {
       EdgesThruHierPinIterator edge_iter(pin, network_, graph_);
       while (edge_iter.hasNext()) {
@@ -5692,8 +5698,9 @@ Sta::findFanoutPins(PinSeq *from,
     }
     else {
       Vertex *vertex = graph_->pinDrvrVertex(pin);
-      findFanoutPins(vertex, flat, endpoints_only, inst_levels, pin_levels, fanout,
-                     pred, mode);
+      if (vertex != nullptr)
+        findFanoutPins(vertex, flat, endpoints_only, inst_levels, pin_levels,
+                       fanout, pred, mode);
     }
   }
   return fanout;
@@ -5730,6 +5737,8 @@ Sta::findFanoutPins(Vertex *from,
                     int pin_level,
                     const Mode *mode)
 {
+  if (from == nullptr)
+    return;
   debugPrint(debug_, "fanout", 1, "{}", from->to_string(this));
   if (!visited.contains(from)) {
     visited.insert(from);

--- a/search/Sta.cc
+++ b/search/Sta.cc
@@ -2713,6 +2713,18 @@ Sta::setCaseInsensitiveMatching(bool enable)
   variables_->setCaseInsensitiveMatching(enable);
 }
 
+bool
+Sta::pinNameCompatibility() const
+{
+  return variables_->pinNameCompatibility();
+}
+
+void
+Sta::setPinNameCompatibility(bool enable)
+{
+  variables_->setPinNameCompatibility(enable);
+}
+
 ////////////////////////////////////////////////////////////////
 
 // Init one scene named "default".
@@ -2787,6 +2799,7 @@ Sta::makeScene(const std::string &name,
       graph_->delayCountChanged();
     updateSceneLiberty(scene, liberty_min_files, liberty_max_files);
     cmd_scene_ = scene;
+    cmd_mode_ = scene->mode();
   }
   else
     report_->error(1572, "mode {} not found.", mode_name);
@@ -5561,8 +5574,12 @@ Sta::findFaninPins(PinSeq *to,
   ensureLevelized();
   mode->sim()->ensureConstantsPropagated();
   PinSet fanin(network_);
+  if (to == nullptr)
+    return fanin;
   FaninSrchPred pred(thru_disabled, thru_constants, this);
   for (const Pin *pin : *to) {
+    if (pin == nullptr)
+      continue;
     if (network_->isHierarchical(pin)) {
       EdgesThruHierPinIterator edge_iter(pin, network_, graph_);
       while (edge_iter.hasNext()) {
@@ -5573,8 +5590,9 @@ Sta::findFaninPins(PinSeq *to,
     }
     else {
       Vertex *vertex = graph_->pinLoadVertex(pin);
-      findFaninPins(vertex, flat, startpoints_only, inst_levels, pin_levels, fanin,
-                    pred, mode);
+      if (vertex != nullptr)
+        findFaninPins(vertex, flat, startpoints_only, inst_levels, pin_levels,
+                      fanin, pred, mode);
     }
   }
   return fanin;

--- a/tcl/Extras.tcl
+++ b/tcl/Extras.tcl
@@ -1025,6 +1025,7 @@ proc alias { args } {
 }
 
 # redirect filename {script}
+# Capture report/console output, not the script's Tcl return value.
 define_cmd_args "redirect" \
   {[-append] [-tee] [-variable var] [-file filename] [filename] script}
 proc redirect { args } {
@@ -1042,21 +1043,50 @@ proc redirect { args } {
     cmd_usage_error "redirect"
   }
 
-  set redirecting 0
-  if { $filename != "" } {
-    if { [info exists flags(-append)] } {
+  set to_var [info exists keys(-variable)]
+  set tee [info exists flags(-tee)]
+  set append [info exists flags(-append)]
+  # Stream to a file unless the output also has to land in a variable or
+  # on the console. Those cases capture to a string first.
+  set file_stream [expr {$filename != "" && !$to_var && !$tee}]
+  set capturing [expr {$to_var || $tee}]
+
+  if { $file_stream } {
+    if { $append } {
       redirect_file_append_begin $filename
     } else {
       redirect_file_begin $filename
     }
-    set redirecting 1
+  } elseif { $capturing } {
+    redirect_string_begin
   }
+
   set code [catch { uplevel 1 $script } ret opts]
-  if { $redirecting } {
+
+  if { $file_stream } {
     redirect_file_end
   }
-  if { [info exists keys(-variable)] } {
-    uplevel 1 [list set $keys(-variable) $ret]
+  if { $capturing } {
+    set output [redirect_string_end]
+    if { $filename != "" } {
+      if { $append } {
+        set stream [open $filename a]
+      } else {
+        set stream [open $filename w]
+      }
+      puts -nonewline $stream $output
+      close $stream
+    }
+    if { $tee } {
+      puts -nonewline $output
+    }
+    if { $to_var } {
+      if { $append } {
+        uplevel 1 [list append $keys(-variable) $output]
+      } else {
+        uplevel 1 [list set $keys(-variable) $output]
+      }
+    }
   }
   if { $code } {
     return -options $opts $ret

--- a/tcl/Extras.tcl
+++ b/tcl/Extras.tcl
@@ -177,6 +177,14 @@ array set get_db_roots {
   libs        {get_libs {}}
   library     {get_libs {}}
   libraries   {get_libs {}}
+  constraint_mode  {get_modes {}}
+  constraint_modes {get_modes {}}
+  mode             {get_modes {}}
+  modes            {get_modes {}}
+  analysis_view    {get_scenes {}}
+  analysis_views   {get_scenes {}}
+  scene            {get_scenes {}}
+  scenes           {get_scenes {}}
 }
 
 # object_type name mapped to the define_property -object_type name.
@@ -191,6 +199,8 @@ array set get_db_prop_types {
   LibertyCell    liberty_cell
   LibertyPort    liberty_port
   LibertyLibrary liberty_library
+  Mode           mode
+  Scene          scene
 }
 
 # object_type name mapped to the .obj_type attribute value.
@@ -205,6 +215,8 @@ array set get_db_obj_types {
   LibertyCell    base_cell
   LibertyPort    base_pin
   LibertyLibrary lib
+  Mode           constraint_mode
+  Scene          analysis_view
 }
 
 # Global scalars read with "get_db name" and written with "set_db name value",
@@ -272,6 +284,17 @@ proc get_db_name_match { pattern name regexp nocase } {
   return [string match $pattern $name]
 }
 
+# Port-name match plus optional sequential pin aliases (CK/CLK, D/d, Q/q).
+proc get_db_port_match { pattern pin regexp nocase } {
+  if { [get_db_name_match $pattern [$pin port_name] $regexp $nocase] } {
+    return 1
+  }
+  if { [pin_name_compatibility] } {
+    return [pin_name_compat_match $pattern $pin $regexp $nocase]
+  }
+  return 0
+}
+
 # A pin pattern matches against the whole hierarchical path, while the sdc
 # network walks the pattern one hierarchy level per separator. Splitting at the
 # last separator and resolving the instance part with -hierarchical (which does
@@ -287,8 +310,7 @@ proc get_db_find_pins { pattern want_hier opts regexp nocase } {
   foreach inst [get_db_to_list [get_cells {*}$opts -hierarchical $inst_pattern]] {
     foreach pin [get_db_inst_pins $inst] {
       if { [$pin is_hierarchical] == $want_hier \
-             && [get_db_name_match $port_pattern [$pin port_name] \
-                   $regexp $nocase] } {
+             && [get_db_port_match $port_pattern $pin $regexp $nocase] } {
         lappend pins $pin
       }
     }
@@ -338,6 +360,9 @@ proc get_db_query { root pattern regexp nocase quiet } {
     set objects [get_db_to_list [get_cells {*}$opts -hierarchical \
                                    -filter "is_hierarchical==$hierarchical" \
                                    $pattern]]
+  } elseif { $getter == "get_modes" || $getter == "get_scenes" } {
+    # These getters do not take -regexp/-nocase; pattern match is glob.
+    set objects [get_db_to_list [$getter -quiet $pattern]]
   } else {
     set objects [get_db_to_list [$getter {*}$opts $pattern]]
   }
@@ -429,6 +454,23 @@ proc get_db_attr { obj attr quiet } {
       return [list $get_db_obj_types($type)]
     }
     return [list $type]
+  } elseif { $attr == "direction" || $attr == "port_direction" \
+               || $attr == "pin_direction" } {
+    # get_db .direction is in/out, not OpenSTA's input/output.
+    set dir [get_db_property $obj $attr $quiet]
+    if { $dir == "input" } {
+      return [list "in"]
+    }
+    if { $dir == "output" } {
+      return [list "out"]
+    }
+    if { $dir == "internal" } {
+      return [list "internal"]
+    }
+    if { $dir == "bidirect" || $dir == "inout" } {
+      return [list "inout"]
+    }
+    return [list $dir]
   }
 
   if { $type == "Pin" } {
@@ -789,6 +831,7 @@ proc get_db { args } {
   set rest [lrange $args 1 end]
 
   set objects [sta::get_db_object_list $first]
+  set attr_path ""
   if { $objects == {} && ![sta::is_object $first] } {
     # Not an object argument, so it names a root collection or a global.
     if { [string trim $first] == "" } {
@@ -806,17 +849,31 @@ proc get_db { args } {
     if { ![info exists sta::get_db_roots($first)] } {
       sta::sta_error 2222 "get_db '$first' is not a supported collection or attribute."
     }
+    # Pattern and .attribute may appear in either order:
+    #   get_db pins *foo* .name
+    #   get_db pins .name *foo*
     set pattern "*"
-    if { [llength $rest] > 0 && [string index [lindex $rest 0] 0] != "." } {
-      set pattern [lindex $rest 0]
-      set rest [lrange $rest 1 end]
+    set pattern_set 0
+    foreach arg $rest {
+      if { [string index $arg 0] == "." } {
+        if { $attr_path != "" } {
+          sta::cmd_usage_error "get_db"
+        }
+        set attr_path $arg
+      } else {
+        if { $pattern_set } {
+          sta::sta_error 2230 "get_db attribute '$arg' must start with '.'."
+        }
+        set pattern $arg
+        set pattern_set 1
+      }
     }
+    set rest {}
     set objects [sta::get_db_query $first $pattern \
                    [info exists flags(-regexp)] [info exists flags(-nocase)] \
                    $quiet]
   }
 
-  set attr_path ""
   if { [llength $rest] > 0 } {
     set attr_path [lindex $rest 0]
     set rest [lrange $rest 1 end]
@@ -950,6 +1007,64 @@ proc suppress_message { args } {
 
 # Add echo alias
 interp alias {} echo {} puts
+
+namespace eval sta {
+
+# alias name definition
+define_cmd_args "alias" {name definition}
+proc alias { args } {
+  if { [llength $args] < 2 } {
+    return
+  }
+  set name [lindex $args 0]
+  set def [lrange $args 1 end]
+  if { [llength $def] == 1 } {
+    set def [lindex $def 0]
+  }
+  interp alias {} $name {} {*}$def
+}
+
+# redirect filename {script}
+define_cmd_args "redirect" \
+  {[-append] [-tee] [-variable var] [-file filename] [filename] script}
+proc redirect { args } {
+  parse_key_args "redirect" args keys {-variable -file} flags {-append -tee}
+  set filename ""
+  if { [info exists keys(-file)] } {
+    set filename $keys(-file)
+  }
+  if { [llength $args] == 2 } {
+    set filename [lindex $args 0]
+    set script [lindex $args 1]
+  } elseif { [llength $args] == 1 } {
+    set script [lindex $args 0]
+  } else {
+    cmd_usage_error "redirect"
+  }
+
+  set redirecting 0
+  if { $filename != "" } {
+    if { [info exists flags(-append)] } {
+      redirect_file_append_begin $filename
+    } else {
+      redirect_file_begin $filename
+    }
+    set redirecting 1
+  }
+  set code [catch { uplevel 1 $script } ret opts]
+  if { $redirecting } {
+    redirect_file_end
+  }
+  if { [info exists keys(-variable)] } {
+    uplevel 1 [list set $keys(-variable) $ret]
+  }
+  if { $code } {
+    return -options $opts $ret
+  }
+  return $ret
+}
+
+}
 
 # Add date getter
 proc date {} {

--- a/tcl/Sta.tcl
+++ b/tcl/Sta.tcl
@@ -81,6 +81,7 @@ proc define_scene { args } {
   define_scene_cmd $name $mode_name \
     $liberty_min_files $liberty_max_files \
     $spef_min_file $spef_max_file
+  follow_cmd_constraint_mode
 }
 
 # deprecated 11/22/2025
@@ -108,6 +109,7 @@ proc set_scene { args } {
     sta_error 578 "$scene_name is not the name of a scene."
   }
   set_cmd_scene $scene
+  follow_cmd_constraint_mode
 }
 
 ################################################################
@@ -169,6 +171,7 @@ define_cmd_args "set_mode" {mode_name}
 proc set_mode { args } {
   check_argc_eq1 "set_mode" $args
   set_cmd_mode [lindex $args 0]
+  follow_cmd_constraint_mode
 }
 
 ################################################################
@@ -183,10 +186,18 @@ proc set_mode { args } {
 # OpenSTA has a single cmd_mode, so SDC lands in the first name and the
 # rest are kept for get_interactive_constraint_modes.
 #
+# set_mode, set_scene, and define_scene change cmd_mode and drop the
+# stored list so get_interactive_constraint_modes follows cmd_mode.
+#
 ################################################################
 
 # Empty means "follow cmd_mode" (including after set_interactive {} ).
 variable interactive_constraint_mode_names {}
+
+proc follow_cmd_constraint_mode {} {
+  variable interactive_constraint_mode_names
+  set interactive_constraint_mode_names {}
+}
 
 proc constraint_mode_name { mode } {
   if { [is_object $mode] && [object_type $mode] == "Mode" } {

--- a/tcl/Sta.tcl
+++ b/tcl/Sta.tcl
@@ -112,10 +112,10 @@ proc set_scene { args } {
 
 ################################################################
 
-define_cmd_args "get_scenes" {[-modes mode_names] [-filter expr] scene_names}
+define_cmd_args "get_scenes" {[-modes mode_names] [-filter expr] [-quiet] scene_names}
 
 proc get_scenes { args } {
-  parse_key_args "get_scenes" args keys {-modes -filter} flags {}
+  parse_key_args "get_scenes" args keys {-modes -filter} flags {-quiet}
   check_argc_eq0or1 "get_scenes" $args
 
   if { [llength $args] == 0 } {
@@ -144,10 +144,10 @@ proc get_scenes { args } {
 
 ################################################################
 
-define_cmd_args "get_modes" {[-filter expr] [mode_name]}
+define_cmd_args "get_modes" {[-filter expr] [-quiet] [mode_name]}
 
 proc get_modes { args } {
-  parse_key_args "get_modes" args keys {-filter} flags {}
+  parse_key_args "get_modes" args keys {-filter} flags {-quiet}
   check_argc_eq0or1 "get_modes" $args
 
   if { [llength $args] == 0 } {
@@ -169,6 +169,105 @@ define_cmd_args "set_mode" {mode_name}
 proc set_mode { args } {
   check_argc_eq1 "set_mode" $args
   set_cmd_mode [lindex $args 0]
+}
+
+################################################################
+#
+# Constraint-mode aliases.
+#
+# OpenSTA mode is the SDC bucket. OpenSTA scene is an analysis view
+# (mode x liberty x parasitics).
+#
+# Interactive constraint modes are the modes subsequent SDC commands
+# write into. Some flows write one command into several modes at once;
+# OpenSTA has a single cmd_mode, so SDC lands in the first name and the
+# rest are kept for get_interactive_constraint_modes.
+#
+################################################################
+
+# Empty means "follow cmd_mode" (including after set_interactive {} ).
+variable interactive_constraint_mode_names {}
+
+proc constraint_mode_name { mode } {
+  if { [is_object $mode] && [object_type $mode] == "Mode" } {
+    return [get_name $mode]
+  }
+  return $mode
+}
+
+define_cmd_args "set_interactive_constraint_modes" {mode_list}
+
+proc set_interactive_constraint_modes { args } {
+  variable interactive_constraint_mode_names
+
+  if { [llength $args] == 0 } {
+    cmd_usage_error "set_interactive_constraint_modes"
+  }
+  if { [llength $args] == 1 } {
+    set modes [lindex $args 0]
+    if { [is_object $modes] } {
+      set modes [list $modes]
+    }
+  } else {
+    set modes $args
+  }
+
+  set names {}
+  foreach mode $modes {
+    set name [constraint_mode_name $mode]
+    if { $name != "" } {
+      lappend names $name
+    }
+  }
+  if { $names == {} } {
+    set interactive_constraint_mode_names {}
+    return
+  }
+
+  foreach name $names {
+    set_cmd_mode $name
+  }
+  set_cmd_mode [lindex $names 0]
+  set interactive_constraint_mode_names $names
+  if { [llength $names] > 1 } {
+    sta_warn 580 "OpenSTA writes SDC to the first interactive constraint mode '[lindex $names 0]'; get_interactive_constraint_modes still returns all [llength $names] names."
+  }
+}
+
+define_cmd_args "get_interactive_constraint_modes" {}
+
+proc get_interactive_constraint_modes { args } {
+  variable interactive_constraint_mode_names
+  check_argc_eq0 "get_interactive_constraint_modes" $args
+  if { $interactive_constraint_mode_names == {} } {
+    return [list [cmd_mode_name]]
+  }
+  return $interactive_constraint_mode_names
+}
+
+define_cmd_alias "get_interactive_constraint_mode" \
+  "get_interactive_constraint_modes"
+
+define_cmd_args "all_constraint_modes" {[-active] [-type static|dynamic]}
+
+proc all_constraint_modes { args } {
+  parse_key_args "all_constraint_modes" args keys {-type} flags {-active}
+  check_argc_eq0 "all_constraint_modes" $args
+
+  if { [info exists keys(-type)] } {
+    set type $keys(-type)
+    if { $type == "dynamic" } {
+      return {}
+    }
+    if { $type != "static" } {
+      sta_error 581 "all_constraint_modes -type must be static or dynamic."
+    }
+  }
+
+  if { [info exists flags(-active)] } {
+    return [get_modes -filter {is_active == true}]
+  }
+  return [get_modes *]
 }
 
 ################################################################

--- a/test/constraint_modes.ok
+++ b/test/constraint_modes.ok
@@ -8,10 +8,12 @@ after set interactive: turbo_ssg_m40
 cmd mode: turbo_ssg_m40
 turbo clocks: turbo_clk
 matched turbo_ssg for turbo_ssg_m40
+after set_mode mode2 interactive: mode2
 mode2 clocks before create: 
 mode2 clocks: mode2_clk
 mode2 is_active: 1
 turbo is_active: 0
+after set_mode turbo interactive: turbo_ssg_m40
 turbo clocks again: turbo_clk
 all mode names: mode2 turbo_ssg_m40
 active name: turbo_ssg_m40
@@ -21,8 +23,8 @@ all_constraint_modes: mode2 turbo_ssg_m40
 all_constraint_modes -active: turbo_ssg_m40
 all_constraint_modes -type static: mode2 turbo_ssg_m40
 all_constraint_modes -type dynamic: ''
-all_constraint_modes bad type: Error 581: constraint_modes.tcl line 57, all_constraint_modes -type must be static or dynamic.
-Warning 580: constraint_modes.tcl line 60, OpenSTA writes SDC to the first interactive constraint mode 'mode2'; get_interactive_constraint_modes still returns all 2 names.
+all_constraint_modes bad type: Error 581: constraint_modes.tcl line 59, all_constraint_modes -type must be static or dynamic.
+Warning 580: constraint_modes.tcl line 62, OpenSTA writes SDC to the first interactive constraint mode 'mode2'; get_interactive_constraint_modes still returns all 2 names.
 multi interactive: mode2 turbo_ssg_m40
 multi cmd mode: mode2
 cleared interactive: mode2
@@ -33,7 +35,9 @@ scenes: scene_mode2 scene_turbo
 views: scene_mode2 scene_turbo
 scene_mode2 is_active: 1
 after define_scene mode2 cmd mode: mode2
+after define_scene mode2 interactive: mode2
 after set_scene active view: scene_turbo
 after set_scene cmd mode: turbo_ssg_m40
+after set_scene interactive: turbo_ssg_m40
 after set_scene turbo is_active: 1
 after set_scene mode2 is_active: 0

--- a/test/constraint_modes.ok
+++ b/test/constraint_modes.ok
@@ -1,0 +1,39 @@
+default interactive: default
+default modes: default
+default obj_type: constraint_mode
+default is_active: 1
+default is_dynamic: 0
+default get_db active: default
+after set interactive: turbo_ssg_m40
+cmd mode: turbo_ssg_m40
+turbo clocks: turbo_clk
+matched turbo_ssg for turbo_ssg_m40
+mode2 clocks before create: 
+mode2 clocks: mode2_clk
+mode2 is_active: 1
+turbo is_active: 0
+turbo clocks again: turbo_clk
+all mode names: mode2 turbo_ssg_m40
+active name: turbo_ssg_m40
+dynamic names: ''
+get_modes -filter active: turbo_ssg_m40
+all_constraint_modes: mode2 turbo_ssg_m40
+all_constraint_modes -active: turbo_ssg_m40
+all_constraint_modes -type static: mode2 turbo_ssg_m40
+all_constraint_modes -type dynamic: ''
+all_constraint_modes bad type: Error 581: constraint_modes.tcl line 57, all_constraint_modes -type must be static or dynamic.
+Warning 580: constraint_modes.tcl line 60, OpenSTA writes SDC to the first interactive constraint mode 'mode2'; get_interactive_constraint_modes still returns all 2 names.
+multi interactive: mode2 turbo_ssg_m40
+multi cmd mode: mode2
+cleared interactive: mode2
+from object: turbo_ssg_m40
+scene_turbo is_active: 1
+after define_scene turbo cmd mode: turbo_ssg_m40
+scenes: scene_mode2 scene_turbo
+views: scene_mode2 scene_turbo
+scene_mode2 is_active: 1
+after define_scene mode2 cmd mode: mode2
+after set_scene active view: scene_turbo
+after set_scene cmd mode: turbo_ssg_m40
+after set_scene turbo is_active: 1
+after set_scene mode2 is_active: 0

--- a/test/constraint_modes.tcl
+++ b/test/constraint_modes.tcl
@@ -34,6 +34,7 @@ foreach cm [get_interactive_constraint_modes] {
 
 # SDC is isolated per mode.
 set_mode mode2
+puts "after set_mode mode2 interactive: [get_interactive_constraint_modes]"
 puts "mode2 clocks before create: [object_names [get_clocks -quiet *]]"
 create_clock -name mode2_clk -period 20 clk1
 puts "mode2 clocks: [object_names [get_clocks -quiet *]]"
@@ -41,6 +42,7 @@ puts "mode2 is_active: [get_property [get_modes mode2] is_active]"
 puts "turbo is_active: [get_property [get_modes turbo_ssg_m40] is_active]"
 
 set_mode turbo_ssg_m40
+puts "after set_mode turbo interactive: [get_interactive_constraint_modes]"
 puts "turbo clocks again: [object_names [get_clocks -quiet *]]"
 
 puts "all mode names: [object_names [get_modes *]]"
@@ -79,8 +81,10 @@ puts "scenes: [object_names [get_scenes *]]"
 puts "views: [lsort [get_db analysis_views * .name]]"
 puts "scene_mode2 is_active: [get_property [get_scenes scene_mode2] is_active]"
 puts "after define_scene mode2 cmd mode: [sta::cmd_mode_name]"
+puts "after define_scene mode2 interactive: [get_interactive_constraint_modes]"
 set_scene scene_turbo
 puts "after set_scene active view: [get_db [get_db analysis_views -if {.is_active}] .name]"
 puts "after set_scene cmd mode: [sta::cmd_mode_name]"
+puts "after set_scene interactive: [get_interactive_constraint_modes]"
 puts "after set_scene turbo is_active: [get_property [get_modes turbo_ssg_m40] is_active]"
 puts "after set_scene mode2 is_active: [get_property [get_modes mode2] is_active]"

--- a/test/constraint_modes.tcl
+++ b/test/constraint_modes.tcl
@@ -1,0 +1,86 @@
+# Constraint-mode aliases on OpenSTA modes/scenes.
+proc object_names { objects } {
+  set names {}
+  foreach_in_collection obj $objects {
+    lappend names [get_name $obj]
+  }
+  return [lsort $names]
+}
+
+read_liberty ../examples/asap7_small_ff.lib.gz
+read_verilog ../examples/reg1_asap7.v
+link_design top
+
+puts "default interactive: [get_interactive_constraint_modes]"
+puts "default modes: [object_names [get_modes *]]"
+puts "default obj_type: [get_db constraint_modes * .obj_type]"
+puts "default is_active: [get_property [get_modes default] is_active]"
+puts "default is_dynamic: [get_property [get_modes default] is_dynamic]"
+# No pattern, -if then .name.
+puts "default get_db active: [get_db [get_db constraint_modes -if {.is_active && !.is_dynamic}] .name]"
+
+# Select a named mode, then apply SDC.
+set_interactive_constraint_modes turbo_ssg_m40
+puts "after set interactive: [get_interactive_constraint_modes]"
+puts "cmd mode: [sta::cmd_mode_name]"
+create_clock -name turbo_clk -period 10 clk1
+puts "turbo clocks: [object_names [get_clocks -quiet *]]"
+
+foreach cm [get_interactive_constraint_modes] {
+  if { [regexp -nocase "turbo_ssg" $cm] } {
+    puts "matched turbo_ssg for $cm"
+  }
+}
+
+# SDC is isolated per mode.
+set_mode mode2
+puts "mode2 clocks before create: [object_names [get_clocks -quiet *]]"
+create_clock -name mode2_clk -period 20 clk1
+puts "mode2 clocks: [object_names [get_clocks -quiet *]]"
+puts "mode2 is_active: [get_property [get_modes mode2] is_active]"
+puts "turbo is_active: [get_property [get_modes turbo_ssg_m40] is_active]"
+
+set_mode turbo_ssg_m40
+puts "turbo clocks again: [object_names [get_clocks -quiet *]]"
+
+puts "all mode names: [object_names [get_modes *]]"
+puts "active name: [get_db [get_db constraint_modes -if {.is_active}] .name]"
+puts "dynamic names: '[get_db [get_db constraint_modes -if {.is_dynamic}] .name]'"
+puts "get_modes -filter active: [object_names [get_modes -filter {is_active == true}]]"
+
+puts "all_constraint_modes: [object_names [all_constraint_modes]]"
+puts "all_constraint_modes -active: [object_names [all_constraint_modes -active]]"
+puts "all_constraint_modes -type static: [object_names [all_constraint_modes -type static]]"
+puts "all_constraint_modes -type dynamic: '[all_constraint_modes -type dynamic]'"
+if { [catch { all_constraint_modes -type bogus } msg] } {
+  puts "all_constraint_modes bad type: $msg"
+}
+
+# Multiple interactive names: SDC still writes to the first.
+set_interactive_constraint_modes {mode2 turbo_ssg_m40}
+puts "multi interactive: [get_interactive_constraint_modes]"
+puts "multi cmd mode: [sta::cmd_mode_name]"
+
+# Empty list (`set_interactive_constraint_modes { }`) follows cmd_mode.
+set_interactive_constraint_modes { }
+puts "cleared interactive: [get_interactive_constraint_modes]"
+
+# Singular alias and object arguments.
+set_interactive_constraint_modes [get_modes turbo_ssg_m40]
+puts "from object: [get_interactive_constraint_mode]"
+
+# Scenes / analysis views. define_scene selects the new scene (and its mode).
+read_spef -name reg1_ff ../examples/reg1_asap7.spef
+define_scene scene_turbo -mode turbo_ssg_m40 -liberty asap7_small_ff -spef reg1_ff
+puts "scene_turbo is_active: [get_property [get_scenes scene_turbo] is_active]"
+puts "after define_scene turbo cmd mode: [sta::cmd_mode_name]"
+define_scene scene_mode2 -mode mode2 -liberty asap7_small_ff -spef reg1_ff
+puts "scenes: [object_names [get_scenes *]]"
+puts "views: [lsort [get_db analysis_views * .name]]"
+puts "scene_mode2 is_active: [get_property [get_scenes scene_mode2] is_active]"
+puts "after define_scene mode2 cmd mode: [sta::cmd_mode_name]"
+set_scene scene_turbo
+puts "after set_scene active view: [get_db [get_db analysis_views -if {.is_active}] .name]"
+puts "after set_scene cmd mode: [sta::cmd_mode_name]"
+puts "after set_scene turbo is_active: [get_property [get_modes turbo_ssg_m40] is_active]"
+puts "after set_scene mode2 is_active: [get_property [get_modes mode2] is_active]"

--- a/test/fanin_empty.ok
+++ b/test/fanin_empty.ok
@@ -1,0 +1,10 @@
+Warning 198: ../examples/gcd_sky130hd.v line 527, module sky130_fd_sc_hd__tapvpwrvgnd_1 not found. Creating black box for TAP_11.
+missing get_fanin 0
+missing all_fanin 0
+empty list get_fanin 0
+empty string get_fanin 0
+missing insts all_fanin 0
+missing -only_cells 0
+missing all_fanout 0
+direct find_fanin_pins 0
+real startpoints 1

--- a/test/fanin_empty.tcl
+++ b/test/fanin_empty.tcl
@@ -1,0 +1,38 @@
+# Empty -to used to pass a null PinSeq* into findFaninPins and abort.
+# get_pins/get_db of missing objects become an empty Tcl list, and
+# tclListSeqPtr returns nullptr when argc == 0.
+read_liberty ../examples/sky130hd_tt.lib.gz
+read_verilog ../examples/gcd_sky130hd.v
+link_design gcd
+create_clock -name clk -period 10 [get_ports clk]
+
+proc show { label objects } {
+  puts "$label [sizeof_collection $objects]"
+}
+
+# Quiet missing pin (same as get_fanin -to of a failed object lookup).
+show "missing get_fanin" \
+  [get_fanin -to [get_pins -quiet -hierarchical *no_such_pin*]]
+show "missing all_fanin" \
+  [all_fanin -to [get_pins -quiet -hierarchical *no_such_pin*]]
+
+# Empty Tcl list / empty string (OpenSTA empty-collection encoding).
+show "empty list get_fanin" [get_fanin -to {}]
+show "empty string get_fanin" [get_fanin -to ""]
+
+# Insts that do not exist, then fanin of that collection (HPM-style).
+show "missing insts all_fanin" \
+  [all_fanin -to [get_db insts -quiet *no_such_inst*]]
+
+# -only_cells goes through find_fanin_insts, which calls findFaninPins.
+show "missing -only_cells" \
+  [get_fanin -only_cells -to [get_pins -quiet *no_such_pin*]]
+show "missing all_fanout" \
+  [all_fanout -from [get_pins -quiet *no_such_pin*]]
+
+# Direct SWIG entry: empty list becomes a null PinSeq*.
+show "direct find_fanin_pins" [sta::find_fanin_pins {} 1 0 0 0 0 0]
+
+# A real pin still has fanin.
+show "real startpoints" \
+  [all_fanin -to [get_ports resp_rdy] -startpoints_only]

--- a/test/get_db.ok
+++ b/test/get_db.ok
@@ -49,21 +49,24 @@ net attr: world
 fanout: u_blk1/blk_r2/Q u_blk1/blk_u1/A u_blk1/blk_u1/Z u_blk2/blk_r3/D u_blk2/blk_u2/A2 u_blk2/blk_u2/ZN
 fanin: u_blk2/blk_r3/CK
 endpoints: u_blk2/blk_r3/D
+attr then pattern: u_blk1/blk_r1/Q
+clk dir: in
+clock in ports: clk1 clk2
 llength: 5
 empty in: ''
-Warning 2233: get_db.tcl line 101, get_db insts 'u_nope/*' not found.
-Warning 2231: get_db.tcl line 102, set_db some_global_attr is not supported, command ignored.
+Warning 2233: get_db.tcl line 106, get_db insts 'u_nope/*' not found.
+Warning 2231: get_db.tcl line 107, set_db some_global_attr is not supported, command ignored.
 bad attr quiet: ''
 Warning 9000: instance objects do not have a no_such_attr property.
 bad attr: ''
-error: Error 2220: get_db.tcl line 120, get_db requires an object collection or attribute name.
-error: Error 2221: get_db.tcl line 120, get_db attribute '.name' has no object collection.
-error: Error 2222: get_db.tcl line 120, get_db 'no_such_collection' is not a supported collection or attribute.
-error: Error 2230: get_db.tcl line 120, get_db attribute 'no_dot' must start with '.'.
-error: Error 2224: get_db.tcl line 120, get_db attribute '.' has an empty component.
-error: Error 2224: get_db.tcl line 120, get_db attribute '.pins..net' has an empty component.
-error: Error 2227: get_db.tcl line 120, get_db -if expression expects an attribute or value.
-error: Error 2226: get_db.tcl line 120, get_db -if expression is missing a ')'.
-error: Error 2228: get_db.tcl line 120, get_db -if expression has trailing garbage.
-error: Error 2232: get_db.tcl line 120, set_db attribute 'no_dot' must start with '.'.
-error: Error 161: get_db.tcl line 120, Usage: set_db objects .attribute value|global_name value
+error: Error 2220: get_db.tcl line 125, get_db requires an object collection or attribute name.
+error: Error 2221: get_db.tcl line 125, get_db attribute '.name' has no object collection.
+error: Error 2222: get_db.tcl line 125, get_db 'no_such_collection' is not a supported collection or attribute.
+error: Error 2230: get_db.tcl line 125, get_db attribute 'no_dot' must start with '.'.
+error: Error 2224: get_db.tcl line 125, get_db attribute '.' has an empty component.
+error: Error 2224: get_db.tcl line 125, get_db attribute '.pins..net' has an empty component.
+error: Error 2227: get_db.tcl line 125, get_db -if expression expects an attribute or value.
+error: Error 2226: get_db.tcl line 125, get_db -if expression is missing a ')'.
+error: Error 2228: get_db.tcl line 125, get_db -if expression has trailing garbage.
+error: Error 2232: get_db.tcl line 125, set_db attribute 'no_dot' must start with '.'.
+error: Error 161: get_db.tcl line 125, Usage: set_db objects .attribute value|global_name value

--- a/test/get_db.tcl
+++ b/test/get_db.tcl
@@ -93,6 +93,11 @@ puts "fanout: [lsort [get_db [all_fanout -from u_blk1/blk_r2/Q] .name]]"
 puts "fanin: [lsort [get_db [all_fanin -to out -startpoints_only] .name]]"
 puts "endpoints: [lsort [get_db [all_fanout -from u_blk1/blk_r2/Q -endpoints_only] .name]]"
 
+# .attribute before pattern.
+puts "attr then pattern: [lsort [get_db pins .name u_blk1/blk_r1/Q]]"
+puts "clk dir: [get_db ports clk1 .direction]"
+puts "clock in ports: [lsort [get_db ports -if {.is_clock_used_as_clock && .direction == in} .name]]"
+
 # Results are Tcl lists, so llength and empty collections behave.
 puts "llength: [llength [get_db insts u_blk*/blk_*]]"
 puts "empty in: '[get_db [get_db -quiet insts no_such_inst] .name]'"

--- a/test/pin_name_compatibility.ok
+++ b/test/pin_name_compatibility.ok
@@ -1,0 +1,46 @@
+######## CK cells, sta_pin_name_compatibility = 0 ########
+default var: 0
+get_pins r1/CK      = {r1/CK}
+get_pins r1/CLK     = {}
+get_pins */CK       = {r1/CK r2/CK r3/CK}
+get_pins */CLK      = {}
+get_pins -hier */CLK = {}
+get_db pins */CLK   = {}
+
+######## CK cells, sta_pin_name_compatibility = 1 ########
+enabled var: 1
+get_pins r1/CLK     = {r1/CK}
+get_pins r1/clk     = {r1/CK}
+get_pins r1/clock   = {r1/CK}
+get_pins */CLK      = {r1/CK r2/CK r3/CK}
+get_pins */CLK*     = {r1/CK r2/CK r3/CK}
+get_pins -hier */CLK = {r1/CK r2/CK r3/CK}
+get_db pins */CLK   = {r1/CK r2/CK r3/CK}
+get_pins r1/d       = {r1/D}
+get_pins r1/q       = {r1/Q}
+get_pins u1/CLK     = {}
+get_pins u1/A       = {u1/A}
+get_pins */CKE      = {}
+
+######## CK cells restored 0 ########
+get_pins r1/CLK     = {}
+Warning 198: ../examples/gcd_sky130hd.v line 527, module sky130_fd_sc_hd__tapvpwrvgnd_1 not found. Creating black box for TAP_11.
+
+######## CLK cells, sta_pin_name_compatibility = 0 ########
+clk pins: 35
+ck pins: 0
+ck* pins: 0
+get_db ck: 0
+
+######## CLK cells, sta_pin_name_compatibility = 1 ########
+clk pins: 35
+ck pins: 35
+ck* pins: 35
+get_db ck: 35
+ck equals clk: 1
+ck* equals clk: 1
+get_db ck equals clk: 1
+leaf CK*: 35
+
+######## CLK cells restored 0 ########
+ck pins: 0

--- a/test/pin_name_compatibility.tcl
+++ b/test/pin_name_compatibility.tcl
@@ -1,0 +1,89 @@
+# Opt-in sequential pin aliases: CK/CLK/clk/clock, D/d, Q/q.
+proc show { label cmd } {
+  set names {}
+  foreach_in_collection obj [eval $cmd] {
+    lappend names [get_full_name $obj]
+  }
+  puts "$label = {[lsort $names]}"
+}
+
+proc count { cmd } {
+  return [sizeof_collection [eval $cmd]]
+}
+
+################################################################
+# These flops use CK. Querying CLK/clk should miss until the
+# compatibility variable is on, then hit the same register clocks.
+################################################################
+read_liberty ../examples/nangate45_typ.lib.gz
+read_verilog ../examples/example1.v
+link_design top
+
+puts "######## CK cells, sta_pin_name_compatibility = 0 ########"
+puts "default var: $sta_pin_name_compatibility"
+show "get_pins r1/CK     " {get_pins -quiet r1/CK}
+show "get_pins r1/CLK    " {get_pins -quiet r1/CLK}
+show "get_pins */CK      " {get_pins -quiet */CK}
+show "get_pins */CLK     " {get_pins -quiet */CLK}
+show "get_pins -hier */CLK" {get_pins -quiet -hierarchical */CLK}
+show "get_db pins */CLK  " {get_db -quiet pins */CLK}
+
+puts ""
+puts "######## CK cells, sta_pin_name_compatibility = 1 ########"
+set sta_pin_name_compatibility 1
+puts "enabled var: $sta_pin_name_compatibility"
+show "get_pins r1/CLK    " {get_pins -quiet r1/CLK}
+show "get_pins r1/clk    " {get_pins -quiet r1/clk}
+show "get_pins r1/clock  " {get_pins -quiet r1/clock}
+show "get_pins */CLK     " {get_pins -quiet */CLK}
+show "get_pins */CLK*    " {get_pins -quiet */CLK*}
+show "get_pins -hier */CLK" {get_pins -quiet -hierarchical */CLK}
+show "get_db pins */CLK  " {get_db -quiet pins */CLK}
+show "get_pins r1/d      " {get_pins -quiet r1/d}
+show "get_pins r1/q      " {get_pins -quiet r1/q}
+# Buffer has no sequential clock; CK/CLK aliases must not invent one.
+show "get_pins u1/CLK    " {get_pins -quiet u1/CLK}
+show "get_pins u1/A      " {get_pins -quiet u1/A}
+# CKE is not a clock-family alias; do not steal enable-style names.
+show "get_pins */CKE     " {get_pins -quiet */CKE}
+
+set sta_pin_name_compatibility 0
+puts ""
+puts "######## CK cells restored 0 ########"
+show "get_pins r1/CLK    " {get_pins -quiet r1/CLK}
+
+################################################################
+# These flops use CLK. Querying CK/CK* should miss until the
+# compatibility variable is on.
+################################################################
+read_liberty ../examples/sky130hd_tt.lib.gz
+read_verilog ../examples/gcd_sky130hd.v
+link_design gcd
+
+puts ""
+puts "######## CLK cells, sta_pin_name_compatibility = 0 ########"
+puts "clk pins: [count {get_pins -quiet -hierarchical */CLK}]"
+puts "ck pins: [count {get_pins -quiet -hierarchical */CK}]"
+puts "ck* pins: [count {get_pins -quiet -hierarchical */CK*}]"
+puts "get_db ck: [llength [get_db -quiet pins */CK]]"
+
+puts ""
+puts "######## CLK cells, sta_pin_name_compatibility = 1 ########"
+set sta_pin_name_compatibility 1
+set clk_n [count {get_pins -quiet -hierarchical */CLK}]
+set ck_n [count {get_pins -quiet -hierarchical */CK}]
+set ckstar_n [count {get_pins -quiet -hierarchical */CK*}]
+set db_ck [llength [get_db -quiet pins */CK]]
+puts "clk pins: $clk_n"
+puts "ck pins: $ck_n"
+puts "ck* pins: $ckstar_n"
+puts "get_db ck: $db_ck"
+puts "ck equals clk: [expr {$ck_n == $clk_n}]"
+puts "ck* equals clk: [expr {$ckstar_n == $clk_n}]"
+puts "get_db ck equals clk: [expr {$db_ck == $clk_n}]"
+puts "leaf CK*: [count {get_pins -quiet *_*/CK*}]"
+
+set sta_pin_name_compatibility 0
+puts ""
+puts "######## CLK cells restored 0 ########"
+puts "ck pins: [count {get_pins -quiet -hierarchical */CK}]"

--- a/test/regression_vars.tcl
+++ b/test/regression_vars.tcl
@@ -148,6 +148,7 @@ record_public_tests {
   disable_clock_gating_check
   disconnect_mcp_pin
   extras
+  fanin_empty
   filter_expr_defined
   filter_expr_to_postfix
   generated_clock

--- a/test/regression_vars.tcl
+++ b/test/regression_vars.tcl
@@ -143,6 +143,7 @@ record_example_tests {
 record_public_tests {
   case_insensitive_matching
   collections
+  constraint_modes
   delay_calc_no_inv
   disable_clock_gating_check
   disconnect_mcp_pin
@@ -182,6 +183,7 @@ record_public_tests {
   path_dedup_silimate
   path_dedup_worst
   path_group_names
+  pin_name_compatibility
   pin_props
   power_calc_no_inv
   power_json
@@ -194,6 +196,7 @@ record_public_tests {
   report_checks_src_attr
   report_json1
   report_json2
+  sdc_compat
   sdc_strip_escaped_bus
   set_path_margin1
   set_path_margin2

--- a/test/sdc_compat.ok
+++ b/test/sdc_compat.ok
@@ -1,0 +1,13 @@
+Warning 198: ../examples/gcd_sky130hd.v line 527, module sky130_fd_sc_hd__tapvpwrvgnd_1 not found. Creating black box for TAP_11.
+alias ok
+RFLATCH size: 0
+glob bus count: 0
+req_msg bits: 32
+clk pin count: 35
+clock in ports: clk
+clk1 is_clock_used_as_clock: 1
+req_val is_clock_used_as_clock: 0
+case set: 1
+case db: 1
+case unset: ''
+empty fanin: 0

--- a/test/sdc_compat.ok
+++ b/test/sdc_compat.ok
@@ -11,3 +11,12 @@ case set: 1
 case db: 1
 case unset: ''
 empty fanin: 0
+captured: hello captured
+sum value: 2
+silent empty: 1
+tee line
+teed: tee line
+both var: both dest
+both file: both dest
+acc: start
+more

--- a/test/sdc_compat.tcl
+++ b/test/sdc_compat.tcl
@@ -1,4 +1,5 @@
 # SDC compatibility helpers used by constraint scripts.
+source helpers.tcl
 read_liberty ../examples/sky130hd_tt.lib.gz
 read_verilog ../examples/gcd_sky130hd.v
 link_design gcd
@@ -45,3 +46,36 @@ puts "case unset: '[get_property $qpin case_value]'"
 # get_fanin on an empty collection must not abort.
 set empty_fanin [get_fanin -to [get_pins -quiet -hierarchical *no_such_pin*]]
 puts "empty fanin: [sizeof_collection $empty_fanin]"
+
+# redirect -variable captures report output, not the script return value.
+redirect -variable captured {
+  report_echo "hello captured"
+}
+puts "captured: [string trimright $captured]"
+set sum [redirect -variable silent_sum {
+  expr {1 + 1}
+}]
+puts "sum value: $sum"
+puts "silent empty: [expr {$silent_sum eq ""}]"
+
+# -tee also writes the captured report to the console.
+redirect -variable teed -tee {
+  report_echo "tee line"
+}
+puts "teed: [string trimright $teed]"
+
+# -file and -variable together get the same report text.
+set redir_file [make_result_file sdc_compat_redirect.txt]
+redirect -file $redir_file -variable both {
+  report_echo "both dest"
+}
+puts "both var: [string trimright $both]"
+set stream [open $redir_file r]
+puts "both file: [string trimright [read $stream]]"
+close $stream
+
+set acc "start\n"
+redirect -variable acc -append {
+  report_echo "more"
+}
+puts "acc: [string trimright $acc]"

--- a/test/sdc_compat.tcl
+++ b/test/sdc_compat.tcl
@@ -1,0 +1,47 @@
+# SDC compatibility helpers used by constraint scripts.
+read_liberty ../examples/sky130hd_tt.lib.gz
+read_verilog ../examples/gcd_sky130hd.v
+link_design gcd
+create_clock -name clk -period 10 [get_ports clk]
+
+# alias name definition
+alias my_echo puts
+my_echo "alias ok"
+
+# redirect /dev/null {script}
+redirect /dev/null {
+  set RFLATCH [get_cells -quiet -hierarchical {*xtRF*latchout*}]
+}
+puts "RFLATCH size: [sizeof_collection $RFLATCH]"
+if {[sizeof_collection $RFLATCH] != 0} {
+  puts "setting multicycle paths"
+}
+
+# get_ports glob with [*] in the middle used to throw std::stoi.
+if { [catch { get_ports -quiet {bus[*]*tail[*]} } gports] } {
+  puts "glob bus error: $gports"
+} else {
+  puts "glob bus count: [sizeof_collection $gports]"
+}
+puts "req_msg bits: [sizeof_collection [get_ports req_msg[*]]]"
+
+# get_db pins .name <pattern>
+puts "clk pin count: [llength [get_db pins .name */CLK]]"
+
+# Clock input ports:
+#   get_ports [get_db ports -if {.is_clock_used_as_clock && .direction == in}]
+puts "clock in ports: [lsort [get_object_name [get_db ports -if {.is_clock_used_as_clock && .direction == in}]]]"
+puts "clk1 is_clock_used_as_clock: [get_property [get_ports clk] is_clock_used_as_clock]"
+puts "req_val is_clock_used_as_clock: [get_property [get_ports req_val] is_clock_used_as_clock]"
+
+# case_value from set_case_analysis
+set dpin [index_collection [get_pins -hierarchical */D] 0]
+set qpin [index_collection [get_pins -hierarchical */Q] 0]
+set_case_analysis 1 $dpin
+puts "case set: [get_property $dpin case_value]"
+puts "case db: [get_db $dpin .case_value]"
+puts "case unset: '[get_property $qpin case_value]'"
+
+# get_fanin on an empty collection must not abort.
+set empty_fanin [get_fanin -to [get_pins -quiet -hierarchical *no_such_pin*]]
+puts "empty fanin: [sizeof_collection $empty_fanin]"


### PR DESCRIPTION
## Summary
- Add interactive constraint-mode/view commands and `get_db` roots so SDC scripts can select modes/scenes, query `is_active`/`is_dynamic`, and write constraints into the command mode.
- Accept remaining SDC Tcl idioms used by constraint scripts: `alias`, `redirect`, either-order `get_db pins` pattern/attribute, `.direction` as `in`/`out`, pin `case_value`, `is_clock_used_as_clock`, glob bus names with `[*]` in the middle, and null-safe `find_fanin_pins`.
- Add opt-in `sta_pin_name_compatibility` so sequential clock/data/output pins match common CK/CLK, D, and Q aliases without inventing clocks on combo cells.

## Test plan
- [ ] `cd test && ./regression -j $(sysctl -n hw.ncpu) all` (84 tests)
- [ ] `constraint_modes`, `sdc_compat`, `pin_name_compatibility`, and `get_db` regressions
- [ ] With `set sta_pin_name_compatibility 1`, `get_pins */CLK*` / `get_db pins */CK` match sequential clock pins across CK/CLK Liberty names


Made with [Cursor](https://cursor.com)