### PR TITLE
Publish MkDocs docs to GitHub Pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,21 +1,23 @@
 name: GitHub Pages
 
-# Preview of MkDocs from the mddocs branch.
-# Enable Pages: Settings → Pages → Deploy from a branch → gh-pages / (root).
+# Publishes MkDocs (mkdocs.yml) to GitHub Pages on every push to main.
+# Pages source: Settings → Pages → Build and deployment → GitHub Actions.
 on:
   push:
-    branches: [mddocs]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
 
 concurrency:
-  group: gh-pages
+  group: pages
   cancel-in-progress: true
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -32,8 +34,21 @@ jobs:
       - name: Build docs
         run: mkdocs build --strict
 
-      - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./site
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ netlist data structures without duplicating them.
 * Query based incremental update of delays, arrival and required times
 * Simulator to propagate constants from constraints and netlist tie high/low
 
+Documentation is published at
+https://silimate.github.io/OpenSTA/.
+
 See [doc/Commands.md](doc/Commands.md) for command documentation.
 See [doc/ChangeLog.md](doc/ChangeLog.md) for changes to commands.
 See [doc/StaApi.md](doc/StaApi.md) for timing engine API documentation.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,8 @@
 site_name: OpenSTA
 site_description: OpenSTA static timing analyzer
-site_url: https://opensta.readthedocs.io
-repo_url: https://github.com/parallaxsw/OpenSTA
+site_url: https://silimate.github.io/OpenSTA/
+repo_url: https://github.com/Silimate/OpenSTA
+repo_name: Silimate/OpenSTA
 edit_uri: ""
 
 docs_dir: doc


### PR DESCRIPTION
## Summary
- Deploy the existing MkDocs Material site from `main` (the previous workflow only listened on a non-existent `mddocs` branch, so Pages never ran).
- Use GitHub's Pages actions instead of pushing a `gh-pages` branch, and point `site_url` / `repo_url` at https://silimate.github.io/OpenSTA/.
- Pages is already set to **GitHub Actions**; the first publish happens when this merges to `main`.

## Test plan
- [x] `mkdocs build --strict` succeeds locally
- [x] Repo Pages source is `workflow` (`https://silimate.github.io/OpenSTA/`)
- [ ] After merge, the **GitHub Pages** workflow deploys and the site loads
- [ ] Command reference (`Commands.md`) and nav pages render with Material theme


Made with [Cursor](https://cursor.com)