### PR TITLE
Support all_inputs/all_outputs -clock and -edge_triggered

### DIFF
--- a/include/sta/Sdc.hh
+++ b/include/sta/Sdc.hh
@@ -220,8 +220,9 @@ public:
   void deleteInstanceBefore(const Instance *inst);
 
   // SWIG sdc interface.
-  // clock_filter / edge_triggered select ports that have set_input_delay
-  // constraints (SDC all_inputs -clock / -edge_triggered).
+  // clock_filter (-clock) selects ports delayed relative to clks.
+  // edge_triggered selects ports with any input/output delay, including
+  // clockless and -reference_pin delays that have no Clock*.
   PortSeq allInputs(bool no_clks,
                     const ClockSet *clks = nullptr,
                     bool clock_filter = false,

--- a/include/sta/Sdc.hh
+++ b/include/sta/Sdc.hh
@@ -220,8 +220,15 @@ public:
   void deleteInstanceBefore(const Instance *inst);
 
   // SWIG sdc interface.
-  PortSeq allInputs(bool no_clks) const;
-  PortSeq allOutputs() const;
+  // clock_filter / edge_triggered select ports that have set_input_delay
+  // constraints (SDC all_inputs -clock / -edge_triggered).
+  PortSeq allInputs(bool no_clks,
+                    const ClockSet *clks = nullptr,
+                    bool clock_filter = false,
+                    bool edge_triggered = false) const;
+  PortSeq allOutputs(const ClockSet *clks = nullptr,
+                     bool clock_filter = false,
+                     bool edge_triggered = false) const;
   AnalysisType analysisType() const { return analysis_type_; }
   void setAnalysisType(AnalysisType analysis_type);
   void setOperatingConditions(OperatingConditions *op_cond,

--- a/sdc/Sdc.cc
+++ b/sdc/Sdc.cc
@@ -421,20 +421,29 @@ Sdc::isConstrained(const Net *net) const
 
 ////////////////////////////////////////////////////////////////
 
+// -edge_triggered (!clock_filter) matches any stored set_input_delay /
+// set_output_delay, including clockless time-0 delays and
+// -reference_pin delays with no -clock (delay->clock() is null).
+// -clock (clock_filter) requires an explicit stored Clock* in clks.
 static bool
 portDelayMatches(const PortDelay *delay,
                  const ClockSet *clks,
                  bool clock_filter)
 {
-  Clock *clk = delay->clock();
   bool matches = false;
-  if (clk != nullptr
-      && (!clock_filter
-          || (clks != nullptr && clks->find(clk) != clks->end())))
+  if (!clock_filter)
     matches = true;
+  else {
+    Clock *clk = delay->clock();
+    if (clk != nullptr
+        && clks != nullptr
+        && clks->find(clk) != clks->end())
+      matches = true;
+  }
   return matches;
 }
 
+// True if the pin has a delay selected by -clock or -edge_triggered.
 template <class DelaySet>
 static bool
 pinHasMatchingPortDelay(const DelaySet *delays,
@@ -457,6 +466,7 @@ Sdc::allInputs(bool no_clks,
                bool clock_filter,
                bool edge_triggered) const
 {
+  // Unfiltered: all input ports. Delay filters use portDelayMatches.
   const bool filter_delays = clock_filter || edge_triggered;
 
   PortSeq ports;
@@ -483,6 +493,7 @@ Sdc::allOutputs(const ClockSet *clks,
                 bool clock_filter,
                 bool edge_triggered) const
 {
+  // Unfiltered: all output ports. Delay filters use portDelayMatches.
   const bool filter_delays = clock_filter || edge_triggered;
 
   PortSeq ports;

--- a/sdc/Sdc.cc
+++ b/sdc/Sdc.cc
@@ -421,9 +421,44 @@ Sdc::isConstrained(const Net *net) const
 
 ////////////////////////////////////////////////////////////////
 
-PortSeq
-Sdc::allInputs(bool no_clks) const
+static bool
+portDelayMatches(const PortDelay *delay,
+                 const ClockSet *clks,
+                 bool clock_filter)
 {
+  Clock *clk = delay->clock();
+  bool matches = false;
+  if (clk != nullptr
+      && (!clock_filter
+          || (clks != nullptr && clks->find(clk) != clks->end())))
+    matches = true;
+  return matches;
+}
+
+template <class DelaySet>
+static bool
+pinHasMatchingPortDelay(const DelaySet *delays,
+                        const ClockSet *clks,
+                        bool clock_filter)
+{
+  bool matches = false;
+  if (delays != nullptr) {
+    for (const auto *delay : *delays) {
+      if (portDelayMatches(delay, clks, clock_filter))
+        matches = true;
+    }
+  }
+  return matches;
+}
+
+PortSeq
+Sdc::allInputs(bool no_clks,
+               const ClockSet *clks,
+               bool clock_filter,
+               bool edge_triggered) const
+{
+  const bool filter_delays = clock_filter || edge_triggered;
+
   PortSeq ports;
   Instance *top_inst = network_->topInstance();
   InstancePinIterator *pin_iter = network_->pinIterator(top_inst);
@@ -432,16 +467,24 @@ Sdc::allInputs(bool no_clks) const
     const Port *port = network_->port(pin);
     PortDirection *dir = network_->direction(port);
     if (dir->isAnyInput()
-        && !(no_clks && isClock(pin)))
-      portMembers(port, ports);
+        && !(no_clks && isClock(pin))) {
+      if (!filter_delays
+          || pinHasMatchingPortDelay(findKey(input_delay_pin_map_, pin),
+                                     clks, clock_filter))
+        portMembers(port, ports);
+    }
   }
   delete pin_iter;
   return ports;
 }
 
 PortSeq
-Sdc::allOutputs() const
+Sdc::allOutputs(const ClockSet *clks,
+                bool clock_filter,
+                bool edge_triggered) const
 {
+  const bool filter_delays = clock_filter || edge_triggered;
+
   PortSeq ports;
   Instance *top_inst = network_->topInstance();
   InstancePinIterator *pin_iter = network_->pinIterator(top_inst);
@@ -449,8 +492,12 @@ Sdc::allOutputs() const
     const Pin *pin = pin_iter->next();
     const Port *port = network_->port(pin);
     PortDirection *dir = network_->direction(port);
-    if (dir->isAnyOutput())
-      portMembers(port, ports);
+    if (dir->isAnyOutput()) {
+      if (!filter_delays
+          || pinHasMatchingPortDelay(findKey(output_delay_pin_map_, pin),
+                                     clks, clock_filter))
+        portMembers(port, ports);
+    }
   }
   delete pin_iter;
   return ports;

--- a/sdc/Sdc.i
+++ b/sdc/Sdc.i
@@ -1491,21 +1491,31 @@ set_clk_thru_tristate_enabled(bool enabled)
 }
 
 PortSeq
-all_inputs_cmd(bool no_clocks)
+all_inputs_cmd(bool no_clocks,
+               ClockSet *clks,
+               bool clock_filter,
+               bool edge_triggered)
 {
   Sta *sta = Sta::sta();
   const Sdc *sdc = sta->cmdSdc();
   sta->ensureLinked();
-  return sdc->allInputs(no_clocks);
+  PortSeq ports = sdc->allInputs(no_clocks, clks, clock_filter,
+                                 edge_triggered);
+  delete clks;
+  return ports;
 }
 
 PortSeq
-all_outputs_cmd()
+all_outputs_cmd(ClockSet *clks,
+                bool clock_filter,
+                bool edge_triggered)
 {
   Sta *sta = Sta::sta();
   const Sdc *sdc = sta->cmdSdc();
   sta->ensureLinked();
-  return sdc->allOutputs();
+  PortSeq ports = sdc->allOutputs(clks, clock_filter, edge_triggered);
+  delete clks;
+  return ports;
 }
 
 ////////////////////////////////////////////////////////////////

--- a/sdc/Sdc.tcl
+++ b/sdc/Sdc.tcl
@@ -265,27 +265,53 @@ proc all_clocks { } {
 
 ################################################################
 
-define_cmd_args "all_inputs" {[-no_clocks -exclude_clock_ports]} \
-  -help {The `all_inputs` command returns a list of all input and bidirect ports of the current design.} \
+define_cmd_args "all_inputs" \
+  {[-clock clocks] [-no_clocks -exclude_clock_ports] [-edge_triggered]} \
+  -help {The `all_inputs` command returns a list of all input and bidirect ports of the current design.
+
+`-clock` and `-edge_triggered` restrict the result to ports that have a matching `set_input_delay`.} \
   -arg_help {
+    -clock {`clocks`: Return inputs constrained relative to these clocks.}
     -no_clocks {Exclude inputs defined as clock sources.}
     -exclude_clock_ports {Alias for `-no_clocks`.}
+    -edge_triggered {Return inputs constrained by `set_input_delay`.}
   }
 
 proc all_inputs { args } {
-  parse_key_args "all_inputs" args keys {} flags {-no_clocks -exclude_clock_ports}
+  parse_key_args "all_inputs" args keys {-clock} \
+    flags {-no_clocks -exclude_clock_ports -edge_triggered}
+  check_argc_eq0 "all_inputs" $args
   set no_clks [expr [info exists flags(-no_clocks)] || [info exists flags(-exclude_clock_ports)]]
-  return [all_inputs_cmd $no_clks]
+  set clock_filter [info exists keys(-clock)]
+  set clks {}
+  if { $clock_filter } {
+    set clks [get_clocks_warn "clocks" $keys(-clock)]
+  }
+  set edge_triggered [info exists flags(-edge_triggered)]
+  return [all_inputs_cmd $no_clks $clks $clock_filter $edge_triggered]
 }
 
 ################################################################
 
-define_cmd_args "all_outputs" {} \
-  -help {The `all_outputs` command returns a list of all output and bidirect ports of the design.}
+define_cmd_args "all_outputs" {[-clock clocks] [-edge_triggered]} \
+  -help {The `all_outputs` command returns a list of all output and bidirect ports of the design.
+
+`-clock` and `-edge_triggered` restrict the result to ports that have a matching `set_output_delay`.} \
+  -arg_help {
+    -clock {`clocks`: Return outputs constrained relative to these clocks.}
+    -edge_triggered {Return outputs constrained by `set_output_delay`.}
+  }
 
 proc all_outputs { args } {
+  parse_key_args "all_outputs" args keys {-clock} flags {-edge_triggered}
   check_argc_eq0 "all_outputs" $args
-  return [all_outputs_cmd]
+  set clock_filter [info exists keys(-clock)]
+  set clks {}
+  if { $clock_filter } {
+    set clks [get_clocks_warn "clocks" $keys(-clock)]
+  }
+  set edge_triggered [info exists flags(-edge_triggered)]
+  return [all_outputs_cmd $clks $clock_filter $edge_triggered]
 }
 
 ################################################################

--- a/test/all_inputs_filters.ok
+++ b/test/all_inputs_filters.ok
@@ -1,0 +1,31 @@
+before delays
+all_inputs
+clk1
+clk2
+clk3
+in1
+in2
+all_inputs -no_clocks
+in1
+in2
+all_inputs -edge_triggered
+all_outputs -edge_triggered
+after in1/out delays
+all_inputs -edge_triggered
+in1
+all_inputs -clock clk
+in1
+all_outputs -edge_triggered
+out
+all_outputs -clock clk
+out
+all_outputs -clock vclk
+INPUT_PORTS_WITHOUT_DELAY
+in2
+all_inputs -edge_triggered after default
+in1
+in2
+all_inputs -clock vclk
+in2
+all_inputs -clock clk -edge_triggered
+in1

--- a/test/all_inputs_filters.ok
+++ b/test/all_inputs_filters.ok
@@ -29,3 +29,17 @@ all_inputs -clock vclk
 in2
 all_inputs -clock clk -edge_triggered
 in1
+after clockless in2
+all_inputs -edge_triggered
+in1
+in2
+all_inputs -clock vclk
+all_inputs -clock clk
+in1
+after ref_pin in2
+all_inputs -edge_triggered
+in1
+in2
+all_inputs -clock clk
+in1
+INPUT_PORTS_WITHOUT_DELAY after ref_pin

--- a/test/all_inputs_filters.tcl
+++ b/test/all_inputs_filters.tcl
@@ -1,0 +1,42 @@
+# SDC/Innovus all_inputs / all_outputs -clock / -edge_triggered.
+source helpers.tcl
+read_liberty ../examples/nangate45_slow.lib.gz
+read_verilog ../examples/example1.v
+link_design top
+
+create_clock -name clk -period 10 {clk1 clk2 clk3}
+create_clock -name vclk -period 10
+
+proc show { label coll } {
+  puts $label
+  report_object_full_names $coll
+}
+
+puts "before delays"
+show "all_inputs" [all_inputs]
+show "all_inputs -no_clocks" [all_inputs -no_clocks]
+show "all_inputs -edge_triggered" [all_inputs -edge_triggered]
+show "all_outputs -edge_triggered" [all_outputs -edge_triggered]
+
+set_input_delay -clock clk 1.0 in1
+set_output_delay -clock clk 1.0 out
+
+puts "after in1/out delays"
+show "all_inputs -edge_triggered" [all_inputs -edge_triggered]
+show "all_inputs -clock clk" [all_inputs -clock clk]
+show "all_outputs -edge_triggered" [all_outputs -edge_triggered]
+show "all_outputs -clock clk" [all_outputs -clock clk]
+show "all_outputs -clock vclk" [all_outputs -clock vclk]
+
+# Typical Innovus flow: default 0 delay on unconstrained non-clock inputs.
+set ALL_IN_EXCEPT_CLK [all_inputs -no_clocks]
+set INPUT_PORTS_WITHOUT_DELAY \
+  [remove_from_collection $ALL_IN_EXCEPT_CLK [all_inputs -edge_triggered]]
+show "INPUT_PORTS_WITHOUT_DELAY" $INPUT_PORTS_WITHOUT_DELAY
+if { [sizeof_collection $INPUT_PORTS_WITHOUT_DELAY] > 0 } {
+  set_input_delay 0 -clock vclk $INPUT_PORTS_WITHOUT_DELAY
+}
+show "all_inputs -edge_triggered after default" [all_inputs -edge_triggered]
+show "all_inputs -clock vclk" [all_inputs -clock vclk]
+show "all_inputs -clock clk -edge_triggered" \
+  [all_inputs -clock clk -edge_triggered]

--- a/test/all_inputs_filters.tcl
+++ b/test/all_inputs_filters.tcl
@@ -40,3 +40,20 @@ show "all_inputs -edge_triggered after default" [all_inputs -edge_triggered]
 show "all_inputs -clock vclk" [all_inputs -clock vclk]
 show "all_inputs -clock clk -edge_triggered" \
   [all_inputs -clock clk -edge_triggered]
+
+# Clockless delay (time 0) is still a stored constraint.
+set_input_delay 2.0 in2
+puts "after clockless in2"
+show "all_inputs -edge_triggered" [all_inputs -edge_triggered]
+show "all_inputs -clock vclk" [all_inputs -clock vclk]
+show "all_inputs -clock clk" [all_inputs -clock clk]
+
+# Reference-pin delay without -clock has delay->clock() == nullptr.
+set_input_delay -reference_pin clk1 1.5 in2
+puts "after ref_pin in2"
+show "all_inputs -edge_triggered" [all_inputs -edge_triggered]
+show "all_inputs -clock clk" [all_inputs -clock clk]
+set ALL_IN_EXCEPT_CLK [all_inputs -no_clocks]
+set INPUT_PORTS_WITHOUT_DELAY \
+  [remove_from_collection $ALL_IN_EXCEPT_CLK [all_inputs -edge_triggered]]
+show "INPUT_PORTS_WITHOUT_DELAY after ref_pin" $INPUT_PORTS_WITHOUT_DELAY

--- a/test/regression_vars.tcl
+++ b/test/regression_vars.tcl
@@ -141,6 +141,7 @@ record_example_tests {
 }
 
 record_public_tests {
+  all_inputs_filters
   case_insensitive_matching
   collections
   constraint_modes


### PR DESCRIPTION
## Summary
- Add SDC/Innovus `all_inputs` / `all_outputs` `-clock` and `-edge_triggered` filters so scripts can select ports that already have a clocked `set_input_delay` / `set_output_delay`.
- This unblocks the common remainder pattern: subtract `[all_inputs -edge_triggered]` from non-clock inputs, then apply a default delay to the unconstrained ports.

## Test plan
- [x] `test/regression all_inputs_filters`
- [x] `slash_port_test` and `sdc_compat` still pass


Made with [Cursor](https://cursor.com)