### PR TITLE
[ENG-2613] Liberty file power calculation selection

### DIFF
--- a/power/Power.cc
+++ b/power/Power.cc
@@ -482,8 +482,7 @@ Power::power(const Instance *inst,
     powerInside(inst, scene, result);
     return result;
   }
-  // SILIMATE: price and cache this leaf only. findInstPowers() would walk the
-  // whole netlist, which report_power -instances / -exclude_libs does not need.
+  // Price and cache the leaf instance.
   auto itr = instance_powers_.find(inst);
   if (itr != instance_powers_.end())
     return itr->second;

--- a/power/Power.cc
+++ b/power/Power.cc
@@ -127,6 +127,7 @@ Power::activitiesInvalid()
 {
   activities_valid_ = false;
   instance_powers_valid_ = false;
+  instance_powers_.clear();
 }
 
 void
@@ -474,14 +475,24 @@ Power::power(const Instance *inst,
              const Scene *scene)
 {
   ensureActivities(scene);
-  ensureInstPowers();
   if (network_->isHierarchical(inst)) {
+    // Hierarchical sums walk every leaf inside, so fill the whole cache.
+    ensureInstPowers();
     PowerResult result;
     powerInside(inst, scene, result);
     return result;
   }
-  else
-    return instance_powers_[inst];
+  // SILIMATE: price and cache this leaf only. findInstPowers() would walk the
+  // whole netlist, which report_power -instances / -exclude_libs does not need.
+  auto itr = instance_powers_.find(inst);
+  if (itr != instance_powers_.end())
+    return itr->second;
+  PowerResult result;
+  LibertyCell *cell = network_->libertyCell(inst);
+  if (cell)
+    result = power(inst, cell, scene_);
+  instance_powers_[inst] = result;
+  return result;
 }
 
 void
@@ -904,6 +915,7 @@ Power::ensureActivities(const Scene *scene)
   if (scene != scene_) {
     scene_ = scene;
     activities_valid_ = false;
+    instance_powers_valid_ = false;
     instance_powers_.clear();
   }
 
@@ -1846,6 +1858,7 @@ void
 Power::powerInvalid()
 {
   activities_valid_ = false;
+  instance_powers_valid_ = false;
   instance_powers_.clear();
   scene_ = nullptr;
 }

--- a/power/Power.i
+++ b/power/Power.i
@@ -27,7 +27,12 @@
 %{
 #include "power/Power.hh"
 
+#include <string>
+
+#include "Liberty.hh"
 #include "Mode.hh"
+#include "Network.hh"
+#include "PatternMatch.hh"
 #include "Sdc.hh"
 #include "Sta.hh"
 #include "power/SaifReader.hh"
@@ -84,6 +89,34 @@ report_power_insts_json(const InstanceSeq insts,
 {
   Sta *sta = Sta::sta();
   sta->reportPowerInstsJson(insts, scene, digits);
+}
+
+InstanceSeq
+power_insts_not_in_libs(StringSeq lib_patterns)
+{
+  Sta *sta = Sta::sta();
+  Network *network = sta->network();
+  InstanceSeq insts;
+  LeafInstanceIterator *iter = network->leafInstanceIterator();
+  while (iter->hasNext()) {
+    Instance *inst = iter->next();
+    LibertyCell *cell = network->libertyCell(inst);
+    if (cell == nullptr)
+      continue;
+    const std::string &lib_name = cell->libertyLibrary()->name();
+    bool excluded = false;
+    for (const std::string &pattern : lib_patterns) {
+      if (patternMatch(pattern, lib_name)) {
+        excluded = true;
+        break;
+      }
+    }
+    // Add instances that match none of the patterns.
+    if (!excluded)
+      insts.push_back(inst);
+  }
+  delete iter;
+  return insts;
 }
 
 ////////////////////////////////////////////////////////////////

--- a/power/Power.tcl
+++ b/power/Power.tcl
@@ -98,6 +98,9 @@ proc_redirect report_power {
       report_power_insts $insts $scene $digits
     }
   } elseif { [info exists keys(-exclude_libs)] } {
+    if { ![string is list $keys(-exclude_libs)] } {
+      sta_error 312 "-exclude_libs is not a list."
+    }
     set insts [power_insts_not_in_libs $keys(-exclude_libs)]
     if { $format == "json" } {
       report_power_insts_json $insts $scene $digits

--- a/power/Power.tcl
+++ b/power/Power.tcl
@@ -32,6 +32,7 @@ namespace eval sta {
 
 define_cmd_args "report_power" \
   { [-instances instances]\
+      [-exclude_libs patterns]\
       [-highest_power_instances count]\
       [-scene scene]\
       [-digits digits]\
@@ -55,6 +56,7 @@ Total                  3.48e-06   6.72e-08   3.12e-07   3.86e-06 100.0%
 ```} \
   -arg_help {
     -instances {`instances`: Report the power for each instance of instances. If the instance is hierarchical the total power for the instances inside the hierarchical instance is reported.}
+    -exclude_libs {`patterns`: Report power for each leaf instance whose Liberty library name matches none of patterns.}
     -highest_power_instances {`count`: Report the power for the count highest power instances.}
     -format {`text`: Print a text table (the default). `json`: Print JSON.}
   }
@@ -63,7 +65,7 @@ proc_redirect report_power {
   global sta_report_default_digits
 
   parse_key_args "report_power" args \
-    keys {-instances -highest_power_instances -corner -scene -format -digits}\
+    keys {-instances -exclude_libs -highest_power_instances -corner -scene -format -digits}\
     flags {}
 
   check_argc_eq0 "report_power" $args
@@ -90,6 +92,13 @@ proc_redirect report_power {
 
   if { [info exists keys(-instances)] } {
     set insts [get_instances_error "-instances" $keys(-instances)]
+    if { $format == "json" } {
+      report_power_insts_json $insts $scene $digits
+    } else {
+      report_power_insts $insts $scene $digits
+    }
+  } elseif { [info exists keys(-exclude_libs)] } {
+    set insts [power_insts_not_in_libs $keys(-exclude_libs)]
     if { $format == "json" } {
       report_power_insts_json $insts $scene $digits
     } else {


### PR DESCRIPTION
## Summary
- After `read_saif`, `report_power` still priced the whole netlist. Blackboxes / other Liberty libs with no useful power models made that walk expensive and noisy.
- Add `report_power -exclude_libs patterns`: report each leaf whose Liberty library name matches **none** of the glob patterns (same per-instance table / JSON path as `-instances`). Instances without a Liberty cell are skipped. If both `-instances` and `-exclude_libs` are given, `-instances` wins.
- Price and cache a single leaf in `Power::power()` instead of calling `ensureInstPowers()` (full netlist). Hierarchical instances still fill the cache. Clear `instance_powers_` / `instance_powers_valid_` on activity, scene, and `powerInvalid()` so a later `read_saif` or `set_power_activity` does not reuse stale leaf results.